### PR TITLE
Optional deactivation of multicasting

### DIFF
--- a/bin/nameserver
+++ b/bin/nameserver
@@ -42,6 +42,8 @@ if __name__ == '__main__':
                         default=None)
     parser.add_argument("-v", "--verbose", help="print debug messages too",
                         action="store_true")
+    parser.add_argument("--no-multicast", help="disable multicasting",
+                        action="store_true")
     opts = parser.parse_args()
 
     if opts.log:
@@ -63,7 +65,9 @@ if __name__ == '__main__':
     logging.getLogger('').addHandler(handler)
     logger = logging.getLogger("nameserver")
 
-    ns = NameServer()
+    multicast_enabled=(opts.no_multicast == False)
+
+    ns = NameServer(multicast_enabled=multicast_enabled)
 
     if opts.daemon is None:
         try:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -28,7 +28,7 @@ Use Example
 The main use of this library is the :class:`posttroll.message.Message`,
 :class:`posttroll.subscriber.Subscribe` and
 :class:`posttroll.publisher.Publish` classes, but the `nameserver` script is
-also necessary. The `namesever` scripts allows to register data publishers and
+also necessary. The `nameserver` scripts allows to register data publishers and
 then for the subscribers to find them. Here is the usage of the `nameserver`
 script::
 
@@ -40,6 +40,7 @@ script::
                           Run as a daemon
     -l LOG, --log LOG     File to log to (defaults to stdout)
     -v, --verbose         print debug messages too
+    --no-multicast        disable address broadcasting via multicasting
 
 
 So, after starting the nameserver, making two processes communicate is fairly
@@ -68,6 +69,26 @@ And the subscribing code::
         with Subscribe("a_service", "counter",) as sub:
             for msg in sub.recv():
                 print msg
+
+If you do not want to broadcast addresses via multicasting to nameservers in your network,
+you can start the nameserver with the argument *--no-multicast*. Doing that, you have 
+to specify the nameserver(s) explicitly in the publishing code::
+
+        from posttroll.publisher import Publish
+            from posttroll.message import Message
+            import time
+
+            try:
+                with Publish("a_service", 9000, nameservers=['localhost']) as pub:
+                    counter = 0
+                    while True:
+                        counter += 1
+                        message = Message("/counter", "info", str(counter))
+                        print "publishing", message
+                        pub.send(str(message))
+                        time.sleep(3)
+            except KeyboardInterrupt:
+                print "terminating publisher..."
 
 .. seealso:: :class:`posttroll.publisher.Publish` 
              and :class:`posttroll.subscriber.Subscribe`

--- a/posttroll/ns.py
+++ b/posttroll/ns.py
@@ -115,17 +115,18 @@ class NameServer(object):
     """The name server.
     """
 
-    def __init__(self, max_age=timedelta(minutes=10)):
+    def __init__(self, max_age=timedelta(minutes=10), multicast_enabled=True):
         self.loop = True
         self.listener = None
         self._max_age = max_age
+        self._multicast_enabled = multicast_enabled
 
     def run(self, *args):
         """Run the listener and answer to requests.
         """
         del args
 
-        arec = AddressReceiver(max_age=self._max_age)
+        arec = AddressReceiver(max_age=self._max_age, multicast_enabled=self._multicast_enabled)
         arec.start()
         port = PORT
 

--- a/posttroll/publisher.py
+++ b/posttroll/publisher.py
@@ -166,12 +166,14 @@ class NoisyPublisher(object):
     list of alternative names for the process. *broadcast_interval*, in seconds
     (2 by default) says how often the current name and address should be
     broadcasted.
-
+    If *nameservers* is non-empty, multicasting will be deactivated and the
+    publisher registers on these nameservers only
     """
 
     _publisher_class = Publisher
 
-    def __init__(self, name, port=0, aliases=None, broadcast_interval=2):
+    def __init__(self, name, port=0, aliases=None, broadcast_interval=2,
+                 nameservers=[]):
         self._name = name
         self._aliases = [name]
         if aliases:
@@ -184,6 +186,7 @@ class NoisyPublisher(object):
         self._broadcast_interval = broadcast_interval
         self._broadcaster = None
         self._publisher = None
+        self._nameservers = nameservers
 
     def start(self):
         """Start the publisher.
@@ -195,7 +198,8 @@ class NoisyPublisher(object):
                 + str(self._publisher.port_number))
         self._broadcaster = sendaddressservice(self._name, addr,
                                                self._aliases,
-                                               self._broadcast_interval).start()
+                                               self._broadcast_interval,
+                                               self._nameservers).start()
         return self._publisher
 
     def send(self, msg):


### PR DESCRIPTION
Added new command line parameter "--no-multicast" to disable listening
on address messages via multicasting. Instead nameserver listens for
direct socket connections on specified port.
Furthermore (client side), new argument "nameservers" added to ctor of NoisyPublisher.
When non-empty, the NoisyPublisher does not use multicast to send
own address to nameservers. Instead, NoisyPublisher connects to each nameserver
directly to promote own address. Specification of nameserver port
is possible. If no port was defined, the default broadcasting bport will be used (21200)
for example: nameservers=['localhost','backupns:1234']