### PR TITLE
broadcast_port and defautl_publish_port can be read from a config file

### DIFF
--- a/doc/example/posttroll.ini
+++ b/doc/example/posttroll.ini
@@ -1,0 +1,3 @@
+[ports]
+broadcast_port = 21601
+default_publish_port = 16561

--- a/posttroll/address_receiver.py
+++ b/posttroll/address_receiver.py
@@ -51,7 +51,7 @@ debug = os.environ.get('DEBUG', False)
 import ConfigParser
 conf = ConfigParser.ConfigParser()
 conf.read(os.path.join(CONFIG_PATH, "posttroll.ini"))
-print(os.path.join(CONFIG_PATH, "posttroll.ini"))
+#print(os.path.join(CONFIG_PATH, "posttroll.ini"))
 broadcast_port = conf.getint('ports', 'broadcast_port') or 21600
 default_publish_port = conf.getint('ports', 'default_publish_port') or 16560
 

--- a/posttroll/address_receiver.py
+++ b/posttroll/address_receiver.py
@@ -32,7 +32,6 @@ import threading
 import errno
 import time
 from mpop import CONFIG_PATH
-
 from datetime import datetime, timedelta
 
 from posttroll.bbmcast import MulticastReceiver, SocketTimeout
@@ -50,10 +49,15 @@ LOGGER = logging.getLogger(__name__)
 debug = os.environ.get('DEBUG', False)
 import ConfigParser
 conf = ConfigParser.ConfigParser()
-conf.read(os.path.join(CONFIG_PATH, "posttroll.ini"))
+posttrollConfig = os.path.join(CONFIG_PATH, "posttroll.ini")
 #print(os.path.join(CONFIG_PATH, "posttroll.ini"))
-broadcast_port = conf.getint('ports', 'broadcast_port') or 21600
-default_publish_port = conf.getint('ports', 'default_publish_port') or 16560
+
+broadcast_port = 21600
+default_publish_port = 16560
+if os.path.isfile(posttrollConfig):
+    conf.read(posttrollConfig)
+    broadcast_port = conf.getint('ports', 'broadcast_port') or 21600
+    default_publish_port = conf.getint('ports', 'default_publish_port') or 16560
 
 #-----------------------------------------------------------------------------
 #

--- a/posttroll/address_receiver.py
+++ b/posttroll/address_receiver.py
@@ -31,6 +31,7 @@ import os
 import threading
 import errno
 import time
+from mpop import CONFIG_PATH
 
 from datetime import datetime, timedelta
 
@@ -47,9 +48,12 @@ __all__ = ('AddressReceiver', 'getaddress')
 LOGGER = logging.getLogger(__name__)
 
 debug = os.environ.get('DEBUG', False)
-broadcast_port = 21200
-
-default_publish_port = 16543
+import ConfigParser
+conf = ConfigParser.ConfigParser()
+conf.read(os.path.join(CONFIG_PATH, "posttroll.ini"))
+print(os.path.join(CONFIG_PATH, "posttroll.ini"))
+broadcast_port = conf.getint('ports', 'broadcast_port') or 21600
+default_publish_port = conf.getint('ports', 'default_publish_port') or 16560
 
 #-----------------------------------------------------------------------------
 #

--- a/posttroll/message_broadcaster.py
+++ b/posttroll/message_broadcaster.py
@@ -25,18 +25,22 @@ import time
 import threading
 import logging
 import errno
+import ConfigParser
+import os
 
 from posttroll import message
 from posttroll.bbmcast import MulticastSender, MC_GROUP
 from posttroll import context
 from zmq import REQ, REP, LINGER
-
+from mpop import CONFIG_PATH
 __all__ = ('MessageBroadcaster', 'AddressBroadcaster', 'sendaddress')
 
 LOGGER = logging.getLogger(__name__)
 
-broadcast_port = 21200
 
+conf = ConfigParser.ConfigParser()
+conf.read(os.path.join(CONFIG_PATH, "posttroll.ini"))
+broadcast_port = conf.getint('ports', 'broadcast_port') or 21200
 
 class DesignatedReceiversSender(object):
 

--- a/posttroll/message_broadcaster.py
+++ b/posttroll/message_broadcaster.py
@@ -39,8 +39,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 conf = ConfigParser.ConfigParser()
-conf.read(os.path.join(CONFIG_PATH, "posttroll.ini"))
-broadcast_port = conf.getint('ports', 'broadcast_port') or 21200
+posttrollConfig = os.path.join(CONFIG_PATH, "posttroll.ini")
+
+broadcast_port = 21200
+if os.path.isfile(posttrollConfig):
+    conf.read(posttrollConfig)
+    broadcast_port = conf.getint('ports', 'broadcast_port') or 21200
 
 class DesignatedReceiversSender(object):
 

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -382,8 +382,10 @@ class _AddressListener(object):
         self.services = services
         self.subscriber = subscriber
         conf = ConfigParser.ConfigParser()
-        conf.read(os.path.join(CONFIG_PATH, "posttroll.ini"))
-        default_publish_port = conf.getint('ports', 'default_publish_port') or 16543
+        posttrollConfig = os.path.join(CONFIG_PATH, "posttroll.ini")
+        default_publish_port = 16543
+        if os.path.isfile(posttrollConfig):
+            default_publish_port = conf.getint('ports', 'default_publish_port') or 16543
         self.subscriber.add_hook_sub("tcp://" + nameserver + ":"+str(default_publish_port),
                                      ["pytroll://address", ],
                                      self.handle_msg)

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -385,6 +385,7 @@ class _AddressListener(object):
         posttrollConfig = os.path.join(CONFIG_PATH, "posttroll.ini")
         default_publish_port = 16543
         if os.path.isfile(posttrollConfig):
+            conf.read(posttrollConfig) 
             default_publish_port = conf.getint('ports', 'default_publish_port') or 16543
         self.subscriber.add_hook_sub("tcp://" + nameserver + ":"+str(default_publish_port),
                                      ["pytroll://address", ],

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -26,8 +26,11 @@
 import logging
 from datetime import datetime, timedelta
 from urlparse import urlsplit
-
+from mpop import CONFIG_PATH
 import time
+import os
+import ConfigParser
+
 # pylint: disable=E0611
 from zmq import (SUB, Poller, LINGER,
                  POLLIN, SUBSCRIBE, PULL, NOBLOCK, ZMQError)
@@ -378,7 +381,10 @@ class _AddressListener(object):
             services = [services, ]
         self.services = services
         self.subscriber = subscriber
-        self.subscriber.add_hook_sub("tcp://" + nameserver + ":16543",
+        conf = ConfigParser.ConfigParser()
+        conf.read(os.path.join(CONFIG_PATH, "posttroll.ini"))
+        default_publish_port = conf.getint('ports', 'default_publish_port') or 16543
+        self.subscriber.add_hook_sub("tcp://" + nameserver + ":"+str(default_publish_port),
                                      ["pytroll://address", ],
                                      self.handle_msg)
 


### PR DESCRIPTION
broadcast_port and defautl_publish_port can be read from a config file called postroll.ini located in the $PPP_CONFIG_DIR (there's an example in the new example directory under doc). If the file is not present, the default are taken (hardcoded in the code).
