### PR TITLE
Expose NSSubscriber kwargs nameserver and addresses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '2.6'
 - '2.7'
 install:
 - pip install .

--- a/posttroll/listener.py
+++ b/posttroll/listener.py
@@ -37,17 +37,21 @@ class ListenerContainer(object):
 
     logger = logging.getLogger("ListenerContainer")
 
-    def __init__(self, topics=None):
+    def __init__(self, topics=None, addresses=None, nameserver="localhost"):
         self.listener = None
         self.output_queue = None
         self.thread = None
+        self.addresses = addresses
+        self.nameserver = nameserver
 
         if topics is not None:
             # Create output_queue for the messages
             self.output_queue = Queue()
 
             # Create a Listener instance
-            self.listener = Listener(topics=topics, queue=self.output_queue)
+            self.listener = Listener(topics=topics, queue=self.output_queue,
+                                     addresses=self.addresses,
+                                     nameserver=self.nameserver)
             # Start Listener instance into a new daemonized thread.
             self.thread = Thread(target=self.listener.run)
             self.thread.setDaemon(True)
@@ -81,13 +85,16 @@ class Listener(object):
 
     logger = logging.getLogger("Listener")
 
-    def __init__(self, topics=None, queue=None):
+    def __init__(self, topics=None, queue=None, addresses=None,
+                 nameserver="localhost"):
         '''Init Listener object
         '''
         self.topics = topics
         self.queue = queue
         self.subscriber = None
         self.recv = None
+        self.addresses = addresses
+        self.nameserver = nameserver
         self.create_subscriber()
         self.running = False
 
@@ -98,7 +105,9 @@ class Listener(object):
         if self.subscriber is None:
             if self.topics:
                 self.subscriber = NSSubscriber("", self.topics,
-                                               addr_listener=True)
+                                               addr_listener=True,
+                                               addresses=self.addresses,
+                                               nameserver=self.nameserver)
                 self.recv = self.subscriber.start().recv
 
     def add_to_queue(self, msg):


### PR DESCRIPTION
This PR exposes nameserver and addresses kwargs to Listener and ListenerContainer. Required for pytroll-collectors PR [7](https://github.com/pytroll/pytroll-collectors/pull/7).