### PR TITLE
Allow posttroll to be used in multiprocessing context

### DIFF
--- a/posttroll/__init__.py
+++ b/posttroll/__init__.py
@@ -28,6 +28,7 @@ import _strptime
 import os
 import zmq
 import logging
+from .version import get_versions
 
 context = {}
 logger = logging.getLogger(__name__)
@@ -43,7 +44,6 @@ def get_context():
         context[pid] = zmq.Context()
         logger.debug('renewed context for PID %d', pid)
     return context[pid]
-
 
 
 def strp_isoformat(strg):
@@ -68,6 +68,6 @@ def strp_isoformat(strg):
         mis = int(float('.' + mis)*1000000)
         return dat.replace(microsecond=mis)
 
-from .version import get_versions
+
 __version__ = get_versions()['version']
 del get_versions

--- a/posttroll/__init__.py
+++ b/posttroll/__init__.py
@@ -32,7 +32,12 @@ import logging
 context = {}
 logger = logging.getLogger(__name__)
 
+
 def get_context():
+    """Provide the context to use.
+
+    This function takes care of creating new contexts in case of forks.
+    """
     pid = os.getpid()
     if pid not in context:
         context[pid] = zmq.Context()

--- a/posttroll/__init__.py
+++ b/posttroll/__init__.py
@@ -22,17 +22,23 @@
 # pytroll.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-assert sys.version[0:3] >= '2.5', 'Python version 2.5 or above is required.'
+
 from datetime import datetime
 import _strptime
-
+import os
 import zmq
-context = zmq.Context()
+import logging
 
+context = {}
+logger = logging.getLogger(__name__)
 
-def renew_context():
-    global context
-    context = zmq.Context()
+def get_context():
+    pid = os.getpid()
+    if pid not in context:
+        context[pid] = zmq.Context()
+        logger.debug('renewed context for PID %d', pid)
+    return context[pid]
+
 
 
 def strp_isoformat(strg):

--- a/posttroll/address_receiver.py
+++ b/posttroll/address_receiver.py
@@ -39,7 +39,7 @@ from zmq import REQ, REP, LINGER, POLLIN, NOBLOCK
 from posttroll.bbmcast import MulticastReceiver, SocketTimeout
 from posttroll.message import Message
 from posttroll.publisher import Publish
-from posttroll import context
+from posttroll import get_context
 
 
 __all__ = ('AddressReceiver', 'getaddress')
@@ -212,7 +212,7 @@ class _SimpleReceiver(object):
 
     def __init__(self, port=None):
         self._port = port or default_publish_port
-        self._socket = context.socket(REP)
+        self._socket = get_context().socket(REP)
         self._socket.bind("tcp://*:" + str(port))
 
     def __call__(self):

--- a/posttroll/message_broadcaster.py
+++ b/posttroll/message_broadcaster.py
@@ -28,7 +28,7 @@ import errno
 
 from posttroll import message
 from posttroll.bbmcast import MulticastSender, MC_GROUP
-from posttroll import context
+from posttroll import get_context
 from zmq import REQ, REP, LINGER
 
 __all__ = ('MessageBroadcaster', 'AddressBroadcaster', 'sendaddress')
@@ -56,7 +56,7 @@ class DesignatedReceiversSender(object):
         """send data to *address* and *port* without verification of response.
         """
         # Socket to talk to server
-        socket = context.socket(REQ)
+        socket = get_context().socket(REQ)
         try:
             socket.setsockopt(LINGER, timeout * 1000)
             if address.find(":") == -1:
@@ -66,7 +66,7 @@ class DesignatedReceiversSender(object):
             socket.send_string(data)
             message = socket.recv_string()
             if message != "ok":
-                logger.warn("invalid acknowledge received: %s" % message)
+                LOGGER.warn("invalid acknowledge received: %s" % message)
 
         finally:
             socket.close()

--- a/posttroll/ns.py
+++ b/posttroll/ns.py
@@ -34,7 +34,7 @@ from threading import Lock
 # pylint: disable=E0611
 from zmq import LINGER, NOBLOCK, POLLIN, REP, REQ, Poller
 
-from posttroll import context
+from posttroll import get_context
 from posttroll.address_receiver import AddressReceiver
 from posttroll.message import Message
 
@@ -79,7 +79,7 @@ def get_pub_address(name, timeout=10, nameserver="localhost"):
     """
 
     # Socket to talk to server
-    socket = context.socket(REQ)
+    socket = get_context().socket(REQ)
     try:
         socket.setsockopt(LINGER, timeout * 1000)
         socket.connect("tcp://" + nameserver + ":" + str(PORT))
@@ -139,7 +139,7 @@ class NameServer(object):
 
         try:
             with nslock:
-                self.listener = context.socket(REP)
+                self.listener = get_context().socket(REP)
                 self.listener.bind("tcp://*:" + str(port))
                 logger.debug('Listening on port %s', str(port))
                 poller = Poller()

--- a/posttroll/publisher.py
+++ b/posttroll/publisher.py
@@ -31,7 +31,7 @@ from six.moves.urllib.parse import urlsplit, urlunsplit
 import six
 import zmq
 
-from posttroll import context
+from posttroll import get_context
 from posttroll.message import Message
 from posttroll.message_broadcaster import sendaddressservice
 
@@ -93,7 +93,7 @@ class Publisher(object):
         # pylint: disable=E1103
         self.name = name
         self.destination = address
-        self.publish = context.socket(zmq.PUB)
+        self.publish = get_context().socket(zmq.PUB)
 
         # Check for port 0 (random port)
         u__ = urlsplit(self.destination)

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -35,7 +35,7 @@ import six
 from zmq import LINGER, NOBLOCK, POLLIN, PULL, SUB, SUBSCRIBE, Poller, ZMQError
 
 # pylint: enable=E0611
-from posttroll import context
+from posttroll import get_context
 from posttroll.message import _MAGICK, Message
 from posttroll.ns import get_pub_address
 
@@ -99,7 +99,7 @@ class Subscriber(object):
             topics = self._magickfy_topics(topics) or self._topics
             LOGGER.info("Subscriber adding address %s with topics %s",
                         str(address), str(topics))
-            subscriber = context.socket(SUB)
+            subscriber = get_context().socket(SUB)
             for t__ in topics:
                 subscriber.setsockopt_string(SUBSCRIBE, six.text_type(t__))
             subscriber.connect(address)
@@ -148,7 +148,7 @@ class Subscriber(object):
         """
         LOGGER.info("Subscriber adding SUB hook %s for topics %s",
                     str(address), str(topics))
-        socket = context.socket(SUB)
+        socket = get_context().socket(SUB)
         for t__ in self._magickfy_topics(topics):
             socket.setsockopt_string(SUBSCRIBE, six.text_type(t__))
         socket.connect(address)
@@ -159,7 +159,7 @@ class Subscriber(object):
         (e.g good for pushed 'inproc' messages from another thread).
         """
         LOGGER.info("Subscriber adding PULL hook %s", str(address))
-        socket = context.socket(PULL)
+        socket = get_context().socket(PULL)
         socket.connect(address)
         self._add_hook(socket, callback)
 


### PR DESCRIPTION
The zeromq context in postroll was until now one shared global variable. While this works in the threaded case, multiprocessing's forking mechanism breaks zeromq as it can't be shared across fork boundaries.

Hence we now create one context per PID to make sure no context is share between processes.