### PR TITLE
Make the range of automatic port selection user definable

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,5 @@
+linters:
+  flake8:
+    fixer: true
+fixers:
+  enable: true

--- a/posttroll/publisher.py
+++ b/posttroll/publisher.py
@@ -38,10 +38,6 @@ from posttroll.message_broadcaster import sendaddressservice
 
 LOGGER = logging.getLogger(__name__)
 
-# Limit port range or use the defaults
-MIN_PORT = int(os.environ.get('POSTTROLL_PUB_MIN_PORT', 49152))
-MAX_PORT = int(os.environ.get('POSTTROLL_PUB_MAX_PORT', 65536))
-
 
 def get_own_ip():
     """Get the host's ip number.
@@ -104,14 +100,19 @@ class Publisher(object):
         self.destination = address
         self.publish = get_context().socket(zmq.PUB)
 
+        # Limit port range or use the defaults when no port is defined
+        # by the user
+        min_port = min_port or int(os.environ.get('POSTTROLL_PUB_MIN_PORT',
+                                                  49152))
+        max_port = max_port or int(os.environ.get('POSTTROLL_PUB_MAX_PORT',
+                                                  65536))
+
         # Check for port 0 (random port)
         u__ = urlsplit(self.destination)
         port = u__.port
         if port == 0:
             dest = urlunsplit((u__.scheme, u__.hostname,
                                u__.path, u__.query, u__.fragment))
-            min_port = min_port or MIN_PORT
-            max_port = max_port or MAX_PORT
             self.port_number = self.publish.bind_to_random_port(
                 dest,
                 min_port=min_port,

--- a/posttroll/publisher.py
+++ b/posttroll/publisher.py
@@ -39,8 +39,8 @@ from posttroll.message_broadcaster import sendaddressservice
 LOGGER = logging.getLogger(__name__)
 
 # Limit port range or use the defaults
-MIN_PORT = os.environ.get('POSTTROLL_PUB_MIN_PORT', 49152)
-MAX_PORT = os.environ.get('POSTTROLL_PUB_MAX_PORT', 65536)
+MIN_PORT = int(os.environ.get('POSTTROLL_PUB_MIN_PORT', 49152))
+MAX_PORT = int(os.environ.get('POSTTROLL_PUB_MAX_PORT', 65536))
 
 
 def get_own_ip():
@@ -107,7 +107,6 @@ class Publisher(object):
         # Check for port 0 (random port)
         u__ = urlsplit(self.destination)
         port = u__.port
-
         if port == 0:
             dest = urlunsplit((u__.scheme, u__.hostname,
                                u__.path, u__.query, u__.fragment))
@@ -207,6 +206,8 @@ class NoisyPublisher(object):
             self._nameservers = nameservers
         else:
             self._nameservers = []
+        self.min_port = min_port
+        self.max_port = max_port
 
     def start(self):
         """Start the publisher.

--- a/posttroll/publisher.py
+++ b/posttroll/publisher.py
@@ -23,6 +23,7 @@
 
 """The publisher module gives high-level tools to publish messages on a port.
 """
+import os
 import logging
 import socket
 from datetime import datetime, timedelta
@@ -36,6 +37,10 @@ from posttroll.message import Message
 from posttroll.message_broadcaster import sendaddressservice
 
 LOGGER = logging.getLogger(__name__)
+
+# Limit port range or use the defaults
+MIN_PORT = os.environ.get('POSTTROLL_PUB_MIN_PORT', 49152)
+MAX_PORT = os.environ.get('POSTTROLL_PUB_MAX_PORT', 65536)
 
 
 def get_own_ip():
@@ -61,7 +66,11 @@ class Publisher(object):
 
       tcp://localhost:1234
 
-    Setting the port to 0 means that a random free port will be chosen for you.
+    Setting the port to 0 means that a random free port will be chosen for
+    you. It is still possible to limit the range from which the port is
+    selected by either setting environment variables POSTTROLL_PUB_MIN_PORT
+    and POSTTROLL_PUB_MAX_PORT, or passing the values, as integers, using
+    arguments min_port and max_port when creating the Publisher.
 
     *name* is simply the name of the publisher.
 
@@ -87,7 +96,7 @@ class Publisher(object):
 
     """
 
-    def __init__(self, address, name=""):
+    def __init__(self, address, name="", min_port=None, max_port=None):
         """Bind the publisher class to a port.
         """
         # pylint: disable=E1103
@@ -102,7 +111,12 @@ class Publisher(object):
         if port == 0:
             dest = urlunsplit((u__.scheme, u__.hostname,
                                u__.path, u__.query, u__.fragment))
-            self.port_number = self.publish.bind_to_random_port(dest)
+            min_port = min_port or MIN_PORT
+            max_port = max_port or MAX_PORT
+            self.port_number = self.publish.bind_to_random_port(
+                dest,
+                min_port=min_port,
+                max_port=max_port)
             netloc = u__.hostname + ":" + str(self.port_number)
             self.destination = urlunsplit((u__.scheme, netloc, u__.path,
                                            u__.query, u__.fragment))
@@ -176,7 +190,7 @@ class NoisyPublisher(object):
     _publisher_class = Publisher
 
     def __init__(self, name, port=0, aliases=None, broadcast_interval=2,
-                 nameservers=None):
+                 nameservers=None, min_port=None, max_port=None):
         self._name = name
         self._aliases = [name]
         if aliases:
@@ -198,7 +212,9 @@ class NoisyPublisher(object):
         """Start the publisher.
         """
         pub_addr = "tcp://*:" + str(self._port)
-        self._publisher = self._publisher_class(pub_addr, self._name)
+        self._publisher = self._publisher_class(pub_addr, self._name,
+                                                min_port=self.min_port,
+                                                max_port=self.max_port)
         LOGGER.debug("entering publish %s", str(self._publisher.destination))
         addr = ("tcp://" + str(get_own_ip()) + ":" +
                 str(self._publisher.port_number))

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -29,16 +29,8 @@ import time
 
 import six
 
-from posttroll.message import Message
-from posttroll.ns import (NameServer, get_pub_addresses,
-                          get_pub_address, TimeoutError)
-from posttroll.publisher import (Publish, Publisher, get_own_ip,
-                                 NoisyPublisher)
-from posttroll.listener import ListenerContainer
-from posttroll.subscriber import Subscribe, Subscriber
-
-
 test_lock = Lock()
+
 
 class TestNS(unittest.TestCase):
 
@@ -46,6 +38,7 @@ class TestNS(unittest.TestCase):
     """
 
     def setUp(self):
+        from posttroll.ns import NameServer
         test_lock.acquire()
         self.ns = NameServer(max_age=timedelta(seconds=3))
         self.thr = Thread(target=self.ns.run)
@@ -60,6 +53,8 @@ class TestNS(unittest.TestCase):
     def test_pub_addresses(self):
         """Test retrieving addresses.
         """
+        from posttroll.ns import get_pub_addresses
+        from posttroll.publisher import Publish
 
         with Publish(six.text_type("data_provider"), 0, ["this_data"]):
             time.sleep(3)
@@ -85,6 +80,9 @@ class TestNS(unittest.TestCase):
     def test_pub_sub_ctx(self):
         """Test publish and subscribe.
         """
+        from posttroll.message import Message
+        from posttroll.publisher import Publish
+        from posttroll.subscriber import Subscribe
 
         with Publish("data_provider", 0, ["this_data"]) as pub:
             with Subscribe("this_data", "counter") as sub:
@@ -102,6 +100,8 @@ class TestNS(unittest.TestCase):
     def test_pub_sub_add_rm(self):
         """Test adding and removing publishers.
         """
+        from posttroll.publisher import Publish
+        from posttroll.subscriber import Subscribe
 
         time.sleep(4)
         with Subscribe("this_data", "counter", True) as sub:
@@ -125,6 +125,7 @@ class TestNSWithoutMulticasting(unittest.TestCase):
     """
 
     def setUp(self):
+        from posttroll.ns import NameServer
         test_lock.acquire()
         self.nameservers = ['localhost']
         self.ns = NameServer(max_age=timedelta(seconds=3),
@@ -141,6 +142,8 @@ class TestNSWithoutMulticasting(unittest.TestCase):
     def test_pub_addresses(self):
         """Test retrieving addresses.
         """
+        from posttroll.ns import get_pub_addresses
+        from posttroll.publisher import Publish
 
         with Publish("data_provider", 0, ["this_data"],
                      nameservers=self.nameservers):
@@ -167,6 +170,9 @@ class TestNSWithoutMulticasting(unittest.TestCase):
     def test_pub_sub_ctx(self):
         """Test publish and subscribe.
         """
+        from posttroll.message import Message
+        from posttroll.publisher import Publish
+        from posttroll.subscriber import Subscribe
 
         with Publish("data_provider", 0, ["this_data"],
                      nameservers=self.nameservers) as pub:
@@ -185,6 +191,8 @@ class TestNSWithoutMulticasting(unittest.TestCase):
     def test_pub_sub_add_rm(self):
         """Test adding and removing publishers.
         """
+        from posttroll.publisher import Publish
+        from posttroll.subscriber import Subscribe
 
         time.sleep(4)
         with Subscribe("this_data", "counter", True) as sub:
@@ -211,6 +219,8 @@ class TestPubSub(unittest.TestCase):
     def test_pub_address_timeout(self):
         """Test timeout in offline nameserver.
         """
+        from posttroll.ns import get_pub_address
+        from posttroll.ns import TimeoutError
 
         self.assertRaises(TimeoutError,
                           get_pub_address, ["this_data"])
@@ -218,6 +228,10 @@ class TestPubSub(unittest.TestCase):
     def test_pub_suber(self):
         """Test publisher and subscriber.
         """
+        from posttroll.message import Message
+        from posttroll.publisher import Publisher
+        from posttroll.publisher import get_own_ip
+        from posttroll.subscriber import Subscriber
 
         pub_address = "tcp://" + str(get_own_ip()) + ":0"
         pub = Publisher(pub_address)
@@ -248,6 +262,9 @@ class TestPub(unittest.TestCase):
         test_lock.release()
 
     def test_pub_unicode(self):
+        from posttroll.message import Message
+        from posttroll.publisher import Publish
+
         message = Message("/pџтяöll", "info", 'hej')
         with Publish("a_service", 9000) as pub:
             try:
@@ -258,6 +275,8 @@ class TestPub(unittest.TestCase):
     def test_pub_minmax_port(self):
         """Test user defined port range"""
         from zmq.error import ZMQError
+        from posttroll.publisher import Publish
+
         # Try over a range of ports just in case the single port is reserved
         for p in range(50000, 60000):
             try:
@@ -275,6 +294,7 @@ class TestListenerContainer(unittest.TestCase):
     """Testing listener container"""
 
     def setUp(self):
+        from posttroll.ns import NameServer
         test_lock.acquire()
         self.ns = NameServer(max_age=timedelta(seconds=3))
         self.thr = Thread(target=self.ns.run)
@@ -288,6 +308,10 @@ class TestListenerContainer(unittest.TestCase):
 
     def test_listener_container(self):
         """Test listener container"""
+        from posttroll.message import Message
+        from posttroll.publisher import NoisyPublisher
+        from posttroll.listener import ListenerContainer
+
         pub = NoisyPublisher("test")
         pub.start()
         sub = ListenerContainer(topics=["/counter"])

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -216,6 +216,12 @@ class TestPubSub(unittest.TestCase):
     """Testing the publishing and subscribing capabilities.
     """
 
+    def setUp(self):
+        test_lock.acquire()
+
+    def tearDown(self):
+        test_lock.release()
+
     def test_pub_address_timeout(self):
         """Test timeout in offline nameserver.
         """

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -281,6 +281,8 @@ class TestPub(unittest.TestCase):
 
     def test_pub_minmax_port(self):
         """Test user defined port range"""
+        import os
+
         # Using environment variables to set port range
         # Try over a range of ports just in case the single port is reserved
         for port in range(40000, 50000):
@@ -310,7 +312,6 @@ class TestPub(unittest.TestCase):
 def _get_port(min_port=None, max_port=None):
     from zmq.error import ZMQError
     from posttroll.publisher import Publish
-    import os
 
     try:
         # Create a publisher to a port selected randomly from

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -281,8 +281,6 @@ class TestPub(unittest.TestCase):
 
     def test_pub_minmax_port(self):
         """Test user defined port range"""
-        import os
-
         # Using environment variables to set port range
         # Try over a range of ports just in case the single port is reserved
         for port in range(40000, 50000):

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -288,6 +288,35 @@ class TestPub(unittest.TestCase):
             except ZMQError:
                 pass
 
+    def test_pub_minmax_port_env(self):
+        """Test user defined port range"""
+        import os
+
+        def _get_port(port):
+            from zmq.error import ZMQError
+            from posttroll.publisher import Publish
+
+            try:
+                # Create a publisher to a port selected randomly from
+                # a 1-port "range"
+                with Publish("a_service") as pub:
+                    return pub.port_number
+            except ZMQError:
+                return False
+
+        # Try over a range of ports just in case the single port is reserved
+        for port in range(50000, 60000):
+            # Set the port range to environment variables
+            os.environ['POSTTROLL_PUB_MIN_PORT'] = str(port)
+            os.environ['POSTTROLL_PUB_MAX_PORT'] = str(port + 1)
+            res = _get_port(port)
+            if res is False:
+                # The port wasn't free, try again
+                continue
+            # Port was selected, make sure it's within the "range" of one
+            self.assertEqual(res, port)
+            break
+
 
 class TestListenerContainer(unittest.TestCase):
 

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -255,6 +255,21 @@ class TestPub(unittest.TestCase):
             except UnicodeDecodeError:
                 self.fail("Sending raised UnicodeDecodeError unexpectedly!")
 
+    def test_pub_minmax_port(self):
+        """Test user defined port range"""
+        from zmq.error import ZMQError
+        # Try over a range of ports just in case the single port is reserved
+        for p in range(50000, 60000):
+            try:
+                # Create a publisher to a port selected randomly from
+                # a 1-port "range"
+                with Publish("a_service", min_port=p, max_port=p+1) as pub:
+                    self.assertEqual(pub.port_number, p)
+                break
+            except ZMQError:
+                pass
+
+
 class TestListenerContainer(unittest.TestCase):
 
     """Testing listener container"""


### PR DESCRIPTION
This PR makes it possible to limit the range from which the publish ports are chosen if no specific port are configured. This is needed for example if firewalls limit the available ports. The range is decided by (in order of precedence):
- user defining `min_port` and/or `max_port` when creating a publisher
- user setting `POSTTROLL_PUB_MIN_PORT` and/or `POSTTROLL_PUB_MAX_PORT` environment variables
- what ever operating system decides (handled by pyzmq)
- default range of `zmq.socket.bind_to_random_port()` (`49152`, `65536`)

The environment variables are needed as none of the software supports the `min_port` and `max_port` parameters yet.