### PR TITLE
Add `restrict_to_localhost` flag for the nameserver

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,5 +1,7 @@
 linters:
   flake8:
     fixer: true
+    python: 3
+    config: setup.cfg
 fixers:
   enable: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-- '3.4'
-- '3.5'
 - '3.6'
+- '3.7'
+- '3.8'
 install:
 - pip install .
 - pip install coveralls

--- a/bin/nameserver
+++ b/bin/nameserver
@@ -45,6 +45,8 @@ if __name__ == '__main__':
                         action="store_true")
     parser.add_argument("--no-multicast", help="disable multicasting",
                         action="store_true")
+    parser.add_argument("-r", "--restrict-to-localhost", help="restrict incomming processes to localhost",
+                        action="store_true")
     opts = parser.parse_args()
 
     if opts.log:
@@ -67,8 +69,9 @@ if __name__ == '__main__':
     logger = logging.getLogger("nameserver")
 
     multicast_enabled = (opts.no_multicast == False)
+    local_only = (opts.restrict_to_localhost)
 
-    ns = NameServer(multicast_enabled=multicast_enabled)
+    ns = NameServer(multicast_enabled=multicast_enabled, restrict_to_localhost=local_only)
 
     if opts.daemon is None:
         try:

--- a/bin/nameserver
+++ b/bin/nameserver
@@ -45,7 +45,7 @@ if __name__ == '__main__':
                         action="store_true")
     parser.add_argument("--no-multicast", help="disable multicasting",
                         action="store_true")
-    parser.add_argument("-r", "--restrict-to-localhost", help="restrict incomming processes to localhost",
+    parser.add_argument("-L", "--local-only", help="accept connections only from localhost",
                         action="store_true")
     opts = parser.parse_args()
 

--- a/posttroll/address_receiver.py
+++ b/posttroll/address_receiver.py
@@ -52,6 +52,7 @@ broadcast_port = 21200
 
 default_publish_port = 16543
 
+
 def get_local_ips():
     inet_addrs = [netifaces.ifaddresses(iface).get(netifaces.AF_INET)
                   for iface in netifaces.interfaces()]

--- a/posttroll/address_receiver.py
+++ b/posttroll/address_receiver.py
@@ -35,7 +35,7 @@ import time
 from datetime import datetime, timedelta
 
 import netifaces
-from zmq import REQ, REP, LINGER, POLLIN, NOBLOCK
+from zmq import REP, LINGER
 
 from posttroll.bbmcast import MulticastReceiver, SocketTimeout
 from posttroll.message import Message
@@ -52,6 +52,9 @@ broadcast_port = 21200
 
 default_publish_port = 16543
 
+ten_minutes = timedelta(minutes=10)
+zero_seconds = timedelta(seconds=0)
+
 
 def get_local_ips():
     inet_addrs = [netifaces.ifaddresses(iface).get(netifaces.AF_INET)
@@ -63,19 +66,17 @@ def get_local_ips():
                 ips.append(add['addr'])
     return ips
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #
 # General thread to receive broadcast addresses.
 #
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 class AddressReceiver(object):
+    """General thread to receive broadcast addresses."""
 
-    """General thread to receive broadcast addresses.
-    """
-
-    def __init__(self, max_age=timedelta(minutes=10), port=None,
+    def __init__(self, max_age=ten_minutes, port=None,
                  do_heartbeat=True, multicast_enabled=True, restrict_to_localhost=False):
         self._max_age = max_age
         self._port = port or default_publish_port
@@ -92,27 +93,23 @@ class AddressReceiver(object):
         self._local_ips = get_local_ips()
 
     def start(self):
-        """Start the receiver.
-        """
+        """Start the receiver."""
         if not self._is_running:
             self._do_run = True
             self._thread.start()
         return self
 
     def stop(self):
-        """Stop the receiver.
-        """
+        """Stop the receiver."""
         self._do_run = False
         return self
 
     def is_running(self):
-        """Check if the receiver is alive.
-        """
+        """Check if the receiver is alive."""
         return self._is_running
 
     def get(self, name=""):
-        """Get the address(es).
-        """
+        """Get the address(es)."""
         addrs = []
 
         with self._address_lock:
@@ -125,9 +122,8 @@ class AddressReceiver(object):
         LOGGER.debug('return address %s', str(addrs))
         return addrs
 
-    def _check_age(self, pub, min_interval=timedelta(seconds=0)):
-        """Check the age of the receiver.
-        """
+    def _check_age(self, pub, min_interval=zero_seconds):
+        """Check the age of the receiver."""
         now = datetime.utcnow()
         if (now - self._last_age_check) <= min_interval:
             return
@@ -150,17 +146,13 @@ class AddressReceiver(object):
                 del self._addresses[addr]
 
     def _run(self):
-        """Run the receiver.
-        """
+        """Run the receiver."""
         port = broadcast_port
         nameservers = []
         if self._multicast_enabled:
-            recv = MulticastReceiver(port).settimeout(2.)
             while True:
                 try:
-                    recv = MulticastReceiver(port).settimeout(2.)
-                    LOGGER.info("Receiver initialized.")
-                    break
+                    recv = MulticastReceiver(port)
                 except IOError as err:
                     if err.errno == errno.ENODEV:
                         LOGGER.error("Receiver initialization failed "
@@ -170,6 +162,11 @@ class AddressReceiver(object):
                         time.sleep(10)
                     else:
                         raise
+                else:
+                    recv.settimeout(tout=2.0)
+                    LOGGER.info("Receiver initialized.")
+                    break
+
         else:
             recv = _SimpleReceiver(port)
             nameservers = ["localhost"]
@@ -216,8 +213,7 @@ class AddressReceiver(object):
                 recv.close()
 
     def _add(self, adr, metadata):
-        """Add an address.
-        """
+        """Add an address."""
         with self._address_lock:
             metadata["receive_time"] = datetime.utcnow()
             self._addresses[adr] = metadata
@@ -225,8 +221,7 @@ class AddressReceiver(object):
 
 class _SimpleReceiver(object):
 
-    """ Simple listing on port for address messages.
-    """
+    """ Simple listing on port for address messages."""
 
     def __init__(self, port=None):
         self._port = port or default_publish_port
@@ -239,11 +234,11 @@ class _SimpleReceiver(object):
         return message, None
 
     def close(self):
-        """Close the receiver.
-        """
+        """Close the receiver."""
         self._socket.setsockopt(LINGER, 1)
         self._socket.close()
 
-#-----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
 # default
 getaddress = AddressReceiver

--- a/posttroll/address_receiver.py
+++ b/posttroll/address_receiver.py
@@ -178,11 +178,12 @@ class AddressReceiver(object):
                 while self._do_run:
                     try:
                         data, fromaddr = recv()
-                        ip_, port = fromaddr
-                        if self._restrict_to_localhost and ip_ not in self._local_ips:
-                            # discard external message
-                            LOGGER.debug('Discard external message')
-                            continue
+                        if self._multicast_enabled:
+                            ip_, port = fromaddr
+                            if self._restrict_to_localhost and ip_ not in self._local_ips:
+                                # discard external message
+                                LOGGER.debug('Discard external message')
+                                continue
                         LOGGER.debug("data %s", data)
                     except SocketTimeout:
                         if self._multicast_enabled:

--- a/posttroll/address_receiver.py
+++ b/posttroll/address_receiver.py
@@ -21,8 +21,9 @@
 # You should have received a copy of the GNU General Public License along with
 # pytroll.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Receive broadcasted addresses in a standard pytroll Message:
+"""Receive broadcasted addresses in a standard pytroll Message.
+
+It will look like:
 /<server-name>/address info ... host:port
 """
 import copy

--- a/posttroll/bbmcast.py
+++ b/posttroll/bbmcast.py
@@ -85,7 +85,7 @@ def mcast_sender(mcgroup=MC_GROUP):
             group = '<broadcast>'
             sock.setsockopt(SOL_SOCKET, SO_BROADCAST, 1)
         elif((int(mcgroup.split(".")[0]) > 239) or
-            (int(mcgroup.split(".")[0]) < 224)):
+             (int(mcgroup.split(".")[0]) < 224)):
             raise IOError("Invalid multicast address.")
         else:
             group = mcgroup

--- a/posttroll/message_broadcaster.py
+++ b/posttroll/message_broadcaster.py
@@ -29,7 +29,7 @@ import errno
 from posttroll import message
 from posttroll.bbmcast import MulticastSender, MC_GROUP
 from posttroll import get_context
-from zmq import REQ, REP, LINGER
+from zmq import REQ, LINGER
 
 __all__ = ('MessageBroadcaster', 'AddressBroadcaster', 'sendaddress')
 
@@ -39,9 +39,7 @@ broadcast_port = 21200
 
 
 class DesignatedReceiversSender(object):
-
-    """Sends message to multiple *receivers* on *port*.
-    """
+    """Sends message to multiple *receivers* on *port*."""
 
     def __init__(self, default_port, receivers):
         self.default_port = default_port
@@ -53,8 +51,7 @@ class DesignatedReceiversSender(object):
             self._send_to_address(receiver, data)
 
     def _send_to_address(self, address, data, timeout=10):
-        """send data to *address* and *port* without verification of response.
-        """
+        """Send data to *address* and *port* without verification of response."""
         # Socket to talk to server
         socket = get_context().socket(REQ)
         try:
@@ -72,8 +69,8 @@ class DesignatedReceiversSender(object):
             socket.close()
 
     def close(self):
-        """Close the sender.
-        """
+        """Close the sender."""
+        pass
 #-----------------------------------------------------------------------------
 #
 # General thread to broadcast messages.
@@ -82,14 +79,12 @@ class DesignatedReceiversSender(object):
 
 
 class MessageBroadcaster(object):
-
     """Class to broadcast stuff.
 
     If *interval* is 0 or negative, no broadcasting is done.
     """
 
     def __init__(self, msg, port, interval, designated_receivers=None):
-
         if designated_receivers:
             self._sender = DesignatedReceiversSender(port,
                                                      designated_receivers)
@@ -105,8 +100,7 @@ class MessageBroadcaster(object):
         self._thread = threading.Thread(target=self._run)
 
     def start(self):
-        """Start the broadcasting.
-        """
+        """Start the broadcasting."""
         if self._interval > 0:
             if not self._is_running:
                 self._do_run = True
@@ -114,19 +108,16 @@ class MessageBroadcaster(object):
         return self
 
     def is_running(self):
-        """Are we running.
-        """
+        """Are we running."""
         return self._is_running
 
     def stop(self):
-        """Stop the broadcasting.
-        """
+        """Stop the broadcasting."""
         self._do_run = False
         return self
 
     def _run(self):
-        """Broadcasts forever.
-        """
+        """Broadcasts forever."""
         self._is_running = True
         network_fail = False
         try:
@@ -157,30 +148,28 @@ class MessageBroadcaster(object):
 
 
 class AddressBroadcaster(MessageBroadcaster):
-
-    """Class to broadcast stuff.
-    """
+    """Class to broadcast stuff."""
 
     def __init__(self, name, address, interval, nameservers):
         msg = message.Message("/address/%s" % name, "info",
                               {"URI": "%s:%d" % address}).encode()
         MessageBroadcaster.__init__(self, msg, broadcast_port, interval,
                                     nameservers)
-#-----------------------------------------------------------------------------
+
+
+# -----------------------------------------------------------------------------
 # default
 sendaddress = AddressBroadcaster
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #
 # General thread to broadcast addresses and type.
 #
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 class AddressServiceBroadcaster(MessageBroadcaster):
-
-    """Class to broadcast stuff.
-    """
+    """Class to broadcast stuff."""
 
     def __init__(self, name, address, data_type, interval=2, nameservers=None):
         msg = message.Message("/address/%s" % name, "info",
@@ -188,6 +177,8 @@ class AddressServiceBroadcaster(MessageBroadcaster):
                                "service": data_type}).encode()
         MessageBroadcaster.__init__(self, msg, broadcast_port, interval,
                                     nameservers)
-#-----------------------------------------------------------------------------
+
+
+# -----------------------------------------------------------------------------
 # default
 sendaddressservice = AddressServiceBroadcaster

--- a/posttroll/ns.py
+++ b/posttroll/ns.py
@@ -49,8 +49,7 @@ nslock = Lock()
 
 class TimeoutError(BaseException):
 
-    """A timeout.
-    """
+    """A timeout."""
     pass
 
 # Client functions.
@@ -66,22 +65,20 @@ def get_pub_addresses(names=None, timeout=10, nameserver="localhost"):
     for name in names:
         then = datetime.now() + timedelta(seconds=timeout)
         while datetime.now() < then:
-            addrs += get_pub_address(name, nameserver=nameserver)
+            addrs += get_pub_address(name, nameserver=nameserver, timeout=timeout)
             if addrs:
                 break
-            time.sleep(.5)
+            time.sleep(timeout / 20.0)
     return addrs
 
 
 def get_pub_address(name, timeout=10, nameserver="localhost"):
     """Get the address of the publisher for a given publisher *name* from the
-    nameserver on *nameserver* (localhost by default).
-    """
-
+    nameserver on *nameserver* (localhost by default)."""
     # Socket to talk to server
     socket = get_context().socket(REQ)
     try:
-        socket.setsockopt(LINGER, timeout * 1000)
+        socket.setsockopt(LINGER, int(timeout * 1000))
         socket.connect("tcp://" + nameserver + ":" + str(PORT))
         logger.debug('Connecting to %s',
                      "tcp://" + nameserver + ":" + str(PORT))
@@ -117,9 +114,7 @@ def get_active_address(name, arec):
 
 
 class NameServer(object):
-
-    """The name server.
-    """
+    """The name server."""
 
     def __init__(self, max_age=timedelta(minutes=10), multicast_enabled=True, restrict_to_localhost=False):
         self.loop = True
@@ -156,8 +151,8 @@ class NameServer(object):
                         continue
                     logger.debug("Replying to request: " + str(msg))
                     msg = Message.decode(msg)
-                    self.listener.send_unicode(six.text_type(get_active_address(
-                        msg.data["service"], arec)))
+                    active_address = get_active_address(msg.data["service"], arec)
+                    self.listener.send_unicode(six.text_type(active_address))
         except KeyboardInterrupt:
             # Needed to stop the nameserver.
             pass

--- a/posttroll/ns.py
+++ b/posttroll/ns.py
@@ -121,11 +121,12 @@ class NameServer(object):
     """The name server.
     """
 
-    def __init__(self, max_age=timedelta(minutes=10), multicast_enabled=True):
+    def __init__(self, max_age=timedelta(minutes=10), multicast_enabled=True, restrict_to_localhost=False):
         self.loop = True
         self.listener = None
         self._max_age = max_age
         self._multicast_enabled = multicast_enabled
+        self._restrict_to_localhost = restrict_to_localhost
 
     def run(self, *args):
         """Run the listener and answer to requests.
@@ -133,7 +134,8 @@ class NameServer(object):
         del args
 
         arec = AddressReceiver(max_age=self._max_age,
-                               multicast_enabled=self._multicast_enabled)
+                               multicast_enabled=self._multicast_enabled,
+                               restrict_to_localhost=self._restrict_to_localhost)
         arec.start()
         port = PORT
 

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -217,7 +217,8 @@ class Subscriber(object):
                         # timeout
                         yield None
                 except ZMQError as err:
-                    LOGGER.exception("Receive failed: %s", str(err))
+                    if self._loop:
+                        LOGGER.exception("Receive failed: %s", str(err))
         finally:
             for sub in list(self.subscribers) + self._hooks:
                 self.poller.unregister(sub)

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -23,6 +23,7 @@
 """Test the publishing and subscribing facilities.
 """
 import unittest
+from unittest import mock
 from datetime import timedelta
 from threading import Thread, Lock
 import time
@@ -361,6 +362,24 @@ class TestListenerContainer(unittest.TestCase):
         sub.stop()
 
 
+class TestAddressReceiver(unittest.TestCase):
+    """Test the AddressReceiver."""
+
+    @mock.patch("posttroll.address_receiver.Message")
+    @mock.patch("posttroll.address_receiver.Publish")
+    @mock.patch("posttroll.address_receiver.MulticastReceiver")
+    def test_localhost_restriction(self, mcrec, pub, msg):
+        mcr_instance = mock.Mock()
+        mcrec.return_value = mcr_instance
+        mcr_instance.return_value = 'blabla', ('255.255.255.255', 12)
+        from posttroll.address_receiver import AddressReceiver
+        adr = AddressReceiver(restrict_to_localhost=True)
+        adr.start()
+        time.sleep(3)
+        msg.decode.assert_not_called()
+        adr.stop()
+
+
 def suite():
     """The suite for test_bbmcast.
     """
@@ -371,5 +390,5 @@ def suite():
     mysuite.addTest(loader.loadTestsFromTestCase(TestNSWithoutMulticasting))
     mysuite.addTest(loader.loadTestsFromTestCase(TestListenerContainer))
     mysuite.addTest(loader.loadTestsFromTestCase(TestPub))
-
+    mysuite.addTest(loader.loadTestsFromTestCase(TestAddressReceiver))
     return mysuite

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -51,14 +51,13 @@ class TestNS(unittest.TestCase):
         test_lock.release()
 
     def test_pub_addresses(self):
-        """Test retrieving addresses.
-        """
+        """Test retrieving addresses."""
         from posttroll.ns import get_pub_addresses
         from posttroll.publisher import Publish
 
-        with Publish(six.text_type("data_provider"), 0, ["this_data"]):
-            time.sleep(3)
-            res = get_pub_addresses(["this_data"])
+        with Publish(six.text_type("data_provider"), 0, ["this_data"], broadcast_interval=0.1):
+            time.sleep(.3)
+            res = get_pub_addresses(["this_data"], timeout=.5)
             self.assertEqual(len(res), 1)
             expected = {u'status': True,
                         u'service': [u'data_provider', u'this_data'],
@@ -98,8 +97,7 @@ class TestNS(unittest.TestCase):
         self.assertTrue(tested)
 
     def test_pub_sub_add_rm(self):
-        """Test adding and removing publishers.
-        """
+        """Test adding and removing publishers."""
         from posttroll.publisher import Publish
         from posttroll.subscriber import Subscribe
 
@@ -212,9 +210,7 @@ class TestNSWithoutMulticasting(unittest.TestCase):
 
 
 class TestPubSub(unittest.TestCase):
-
-    """Testing the publishing and subscribing capabilities.
-    """
+    """Testing the publishing and subscribing capabilities."""
 
     def setUp(self):
         test_lock.acquire()
@@ -229,7 +225,7 @@ class TestPubSub(unittest.TestCase):
         from posttroll.ns import TimeoutError
 
         self.assertRaises(TimeoutError,
-                          get_pub_address, ["this_data"])
+                          get_pub_address, ["this_data", 0.5])
 
     def test_pub_suber(self):
         """Test publisher and subscriber.

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ versionfile_source = posttroll/version.py
 versionfile_build =
 tag_prefix = v
 #parentdir_prefix = myproject-
+
+[flake8]
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -23,14 +23,10 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from setuptools import setup
-import sys
-import imp
 import versioneer
 
 
 requirements = ['pyzmq', 'six', 'netifaces']
-if sys.version_info < (2, 6):
-    requirements.append('simplejson')
 
 
 setup(name="posttroll",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ import imp
 import versioneer
 
 
-requirements = ['pyzmq', 'six']
+requirements = ['pyzmq', 'six', 'netifaces']
 if sys.version_info < (2, 6):
     requirements.append('simplejson')
 


### PR DESCRIPTION
This flag disables the listening to modules publishing on an another host (multicast only).

A test has been added.

Also some cleanup has been performed, and some sockets are now explicitly closed when they could have been left open (could help with the "too many open files" issue some of us have been having).