### PR TITLE
Raise an exception if no sockets to poll

### DIFF
--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -191,6 +191,8 @@ class Subscriber(object):
 
         for sub in list(self.subscribers) + self._hooks:
             self.poller.register(sub, POLLIN)
+        if not self.poller.sockets:
+            raise IOError("No sockect to poll")
         self._loop = True
         try:
             while self._loop:


### PR DESCRIPTION
Trying to receive messages from a not registered service will create an infinite loop, the following code will print `None` forever:

    from posttroll.subscriber import Subscribe
    with Subscribe("invalid_service", "counter",) as sub:
    for msg in sub.recv():
        print(msg)

It's fixed by raising an exception in `Subscriber.recv` if no socket to poll.

I'm some what surprised that we first see this "feature" now ... so please check if I have missed something.