### PR TITLE
Fix filtering of messages by the name of service

### DIFF
--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -402,9 +402,9 @@ class _AddressListener(object):
         addr_ = msg.data["URI"]
         status = msg.data.get('status', True)
         if status:
-            service = msg.data.get('service')
+            msg_services = msg.data.get('service')            
             for service in self.services:
-                if not service or service in service:
+                if not service or service in msg_services:
                     LOGGER.debug("Adding address %s %s", str(addr_),
                                  str(service))
                     self.subscriber.add(addr_)

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -402,7 +402,7 @@ class _AddressListener(object):
         addr_ = msg.data["URI"]
         status = msg.data.get('status', True)
         if status:
-            msg_services = msg.data.get('service')            
+            msg_services = msg.data.get('service')
             for service in self.services:
                 if not service or service in msg_services:
                     LOGGER.debug("Adding address %s %s", str(addr_),

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -116,6 +116,10 @@ class TestNS(unittest.TestCase):
                     break
             time.sleep(3)
             self.assertEqual(len(sub.sub_addr), 0)
+            with Publish("data_provider_2", 0, ["another_data"]):
+                time.sleep(4)
+                six.next(sub.recv(2))
+                self.assertEqual(len(sub.sub_addr), 0)
             sub.close()
 
 
@@ -209,6 +213,11 @@ class TestNSWithoutMulticasting(unittest.TestCase):
 
             time.sleep(3)
             self.assertEqual(len(sub.sub_addr), 0)
+            with Publish("data_provider_2", 0, ["another_data"],
+                         nameservers=self.nameservers):
+                time.sleep(4)
+                six.next(sub.recv(2))
+                self.assertEqual(len(sub.sub_addr), 0)
 
 
 class TestPubSub(unittest.TestCase):


### PR DESCRIPTION
This PR fixes incorrect filtering of messages by service name in NSSubscriber as reported in #24 .