### PR TITLE
Fix link te Github project

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -14,7 +14,7 @@ notifications.
 To get the software, take a look on github_.
 
 .. _pytroll: http://www.pytroll.org
-.. _github: http://github.com/mraspaud/posttroll
+.. _github: http://github.com/pytroll/posttroll
 
 .. contents::
    :local:


### PR DESCRIPTION
The link to the Github project was pointing to mraspaud personal fork of
the repository.  Adapt this to point to the pytroll main repository instead.