### PR TITLE
Add a possibility to create subscribers using a dictionary of configuration options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+exclude: '^$'
+fail_fast: false
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    - id: flake8
+      additional_dependencies: [flake8-docstrings, flake8-debugger, flake8-bugbear]

--- a/posttroll/listener.py
+++ b/posttroll/listener.py
@@ -23,7 +23,7 @@
 
 """Listener module."""
 
-from posttroll.subscriber import NSSubscriber
+from posttroll import subscriber
 from queue import Queue
 from threading import Thread
 import time
@@ -101,11 +101,19 @@ class Listener(object):
         """Create a subscriber instance using specified addresses and message types."""
         if self.subscriber is None:
             if self.topics:
-                self.subscriber = NSSubscriber(self.services, self.topics,
-                                               addr_listener=True,
-                                               addresses=self.addresses,
-                                               nameserver=self.nameserver)
+                config = self._get_subscriber_config()
+                self.subscriber = subscriber.dict_config(config)
                 self.recv = self.subscriber.start().recv
+
+    def _get_subscriber_config(self):
+        config = {
+            'services': self.services,
+            'topics': self.topics,
+            'addr_listener': True,
+            'addresses': self.addresses,
+            'nameserver': self.nameserver,
+        }
+        return config
 
     def add_to_queue(self, msg):
         """Add the message to queue."""

--- a/posttroll/listener.py
+++ b/posttroll/listener.py
@@ -103,10 +103,7 @@ class Listener(object):
             if self.topics:
                 config = self._get_subscriber_config()
                 self.subscriber = subscriber.dict_config(config)
-                try:
-                    self.recv = self.subscriber.start().recv
-                except AttributeError:
-                    self.recv = self.subscriber.recv
+                self.recv = self.subscriber.recv
 
     def _get_subscriber_config(self):
         config = {

--- a/posttroll/listener.py
+++ b/posttroll/listener.py
@@ -21,7 +21,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-'''Listener module.'''
+"""Listener module."""
 
 from posttroll.subscriber import NSSubscriber
 from queue import Queue
@@ -31,13 +31,12 @@ import logging
 
 
 class ListenerContainer(object):
-
-    '''Container for listener instance
-    '''
+    """Container for a listener instance."""
 
     logger = logging.getLogger("ListenerContainer")
 
     def __init__(self, topics=None, addresses=None, nameserver="localhost", services=""):
+        """Initialize the class."""
         self.listener = None
         self.output_queue = None
         self.thread = None
@@ -60,18 +59,18 @@ class ListenerContainer(object):
             self.thread.start()
 
     def __setstate__(self, state):
+        """Re-initialize the class."""
         self.__init__(**state)
 
     def restart_listener(self, topics):
-        '''Restart listener after configuration update.
-        '''
+        """Restart listener after configuration update."""
         if self.listener is not None:
             if self.listener.running:
                 self.stop()
         self.__init__(topics=topics)
 
     def stop(self):
-        '''Stop listener.'''
+        """Stop listener."""
         self.logger.debug("Stopping listener.")
         self.listener.stop()
         if self.thread is not None:
@@ -81,17 +80,13 @@ class ListenerContainer(object):
 
 
 class Listener(object):
-
-    '''PyTroll listener class for reading messages for eg. operational
-    product generation.
-    '''
+    """PyTroll listener class for reading messages for eg. operational product generation."""
 
     logger = logging.getLogger("Listener")
 
     def __init__(self, topics=None, queue=None, addresses=None,
                  nameserver="localhost", services=""):
-        '''Init Listener object
-        '''
+        """Initialize Listener object."""
         self.topics = topics
         self.queue = queue
         self.services = services
@@ -103,9 +98,7 @@ class Listener(object):
         self.running = False
 
     def create_subscriber(self):
-        '''Create a subscriber instance using specified addresses and
-        message types.
-        '''
+        """Create a subscriber instance using specified addresses and message types."""
         if self.subscriber is None:
             if self.topics:
                 self.subscriber = NSSubscriber(self.services, self.topics,
@@ -115,14 +108,11 @@ class Listener(object):
                 self.recv = self.subscriber.start().recv
 
     def add_to_queue(self, msg):
-        '''Add message to queue
-        '''
+        """Add the message to queue."""
         self.queue.put(msg)
 
     def run(self):
-        '''Run listener
-        '''
-
+        """Run the listener."""
         self.running = True
 
         for msg in self.recv(1):
@@ -136,8 +126,7 @@ class Listener(object):
             self.add_to_queue(msg)
 
     def stop(self):
-        '''Stop subscriber and delete the instance
-        '''
+        """Stop subscriber and delete the instance."""
         self.running = False
         time.sleep(1)
         if self.subscriber is not None:
@@ -145,8 +134,7 @@ class Listener(object):
             self.subscriber = None
 
     def restart(self):
-        '''Restart subscriber
-        '''
+        """Restart the listener."""
         self.stop()
         self.create_subscriber()
         self.run()

--- a/posttroll/listener.py
+++ b/posttroll/listener.py
@@ -30,7 +30,7 @@ import time
 import logging
 
 
-class ListenerContainer(object):
+class ListenerContainer:
     """Container for a listener instance."""
 
     logger = logging.getLogger("ListenerContainer")
@@ -79,7 +79,7 @@ class ListenerContainer(object):
         self.logger.debug("Listener stopped.")
 
 
-class Listener(object):
+class Listener:
     """PyTroll listener class for reading messages for eg. operational product generation."""
 
     logger = logging.getLogger("Listener")

--- a/posttroll/listener.py
+++ b/posttroll/listener.py
@@ -23,7 +23,7 @@
 
 """Listener module."""
 
-from posttroll import subscriber
+from posttroll.subscriber import create_subscriber_from_dict_config
 from queue import Queue
 from threading import Thread
 import time
@@ -102,7 +102,7 @@ class Listener(object):
         if self.subscriber is None:
             if self.topics:
                 config = self._get_subscriber_config()
-                self.subscriber = subscriber.dict_config(config)
+                self.subscriber = create_subscriber_from_dict_config(config)
                 self.recv = self.subscriber.recv
 
     def _get_subscriber_config(self):

--- a/posttroll/listener.py
+++ b/posttroll/listener.py
@@ -103,7 +103,10 @@ class Listener(object):
             if self.topics:
                 config = self._get_subscriber_config()
                 self.subscriber = subscriber.dict_config(config)
-                self.recv = self.subscriber.start().recv
+                try:
+                    self.recv = self.subscriber.start().recv
+                except AttributeError:
+                    self.recv = self.subscriber.recv
 
     def _get_subscriber_config(self):
         config = {

--- a/posttroll/publisher.py
+++ b/posttroll/publisher.py
@@ -245,7 +245,7 @@ class Publish(object):
 
     See :class:`Publisher` and :class:`NoisyPublisher` for more information on the arguments.
 
-    The publisher is selected based on the arguments, see :function:`dict_config` for
+    The publisher is selected based on the arguments, see :function:`create_publisher_from_dict_config` for
     information how the selection is done.
 
     Example on how to use the :class:`Publish` context::
@@ -274,7 +274,7 @@ class Publish(object):
         settings = {'name': name, 'port': port, 'min_port': min_port, 'max_port': max_port,
                     'aliases': aliases, 'broadcast_interval': broadcast_interval,
                     'nameservers': nameservers}
-        self.publisher = dict_config(settings)
+        self.publisher = create_publisher_from_dict_config(settings)
 
     def __enter__(self):
         return self.publisher.start()
@@ -283,7 +283,7 @@ class Publish(object):
         self.publisher.stop()
 
 
-def dict_config(settings):
+def create_publisher_from_dict_config(settings):
     """Create a publisher based on dictionary of configuration items.
 
     The publisher is created based on the given options in the following way:

--- a/posttroll/publisher.py
+++ b/posttroll/publisher.py
@@ -52,8 +52,7 @@ def get_own_ip():
     return ip_
 
 
-class Publisher(object):
-
+class Publisher:
     """The publisher class.
 
     *address* is the current address of the Publisher, e.g.::
@@ -150,8 +149,7 @@ class Publisher(object):
         self._heartbeat(min_interval)
 
 
-class _PublisherHeartbeat(object):
-
+class _PublisherHeartbeat:
     """Publisher for heartbeat."""
 
     def __init__(self, publisher):
@@ -169,8 +167,7 @@ class _PublisherHeartbeat(object):
                                         {"min_interval": min_interval}).encode())
 
 
-class NoisyPublisher(object):
-
+class NoisyPublisher:
     """Same as a Publisher, but with broadcasting of its own name and address.
 
     Setting the *name* to a meaningful value is import since it will be
@@ -187,6 +184,7 @@ class NoisyPublisher(object):
 
     def __init__(self, name, port=0, aliases=None, broadcast_interval=2,
                  nameservers=None, min_port=None, max_port=None):
+        """Initialize a noisy publisher."""
         self._name = name
         self._aliases = [name]
         if aliases:
@@ -239,8 +237,7 @@ def _get_publish_address(port, ip_address="*"):
     return "tcp://" + ip_address + ":" + str(port)
 
 
-class Publish(object):
-
+class Publish:
     """The publishing context.
 
     See :class:`Publisher` and :class:`NoisyPublisher` for more information on the arguments.
@@ -277,9 +274,11 @@ class Publish(object):
         self.publisher = create_publisher_from_dict_config(settings)
 
     def __enter__(self):
+        """Enter the context."""
         return self.publisher.start()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit the context."""
         self.publisher.stop()
 
 

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -350,7 +350,7 @@ class Subscribe(object):
 
     See :class:`NSSubscriber` and :class:`Subscriber` for initialization parameters.
 
-    The subscriber is selected based on the arguments, see :function:`dict_config` for
+    The subscriber is selected based on the arguments, see :function:`create_subscriber_from_dict_config` for
     information how the selection is done.
 
     Example::
@@ -377,7 +377,7 @@ class Subscribe(object):
             'timeout': timeout,
             'nameserver': nameserver,
         }
-        self.subscriber = dict_config(settings)
+        self.subscriber = create_subscriber_from_dict_config(settings)
 
     def __enter__(self):
         """Start the subscriber when used as a context manager."""
@@ -427,7 +427,7 @@ class _AddressListener(object):
             self.subscriber.remove(addr_)
 
 
-def dict_config(settings):
+def create_subscriber_from_dict_config(settings):
     """Get a subscriber class instance defined by a dictionary of configuration options.
 
     The subscriber is created based on the given options in the following way:

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -42,7 +42,7 @@ from posttroll.ns import get_pub_address
 LOGGER = logging.getLogger(__name__)
 
 
-class Subscriber(object):
+class Subscriber:
     """Class for subscribing to message streams.
 
     Subscribes to *addresses* for *topics*, and perform address translation of
@@ -265,7 +265,7 @@ class Subscriber(object):
                 pass
 
 
-class NSSubscriber(object):
+class NSSubscriber:
     """Automatically subscribe to *services*.
 
     Automatic subscriptions are done by requesting addresses from the
@@ -345,7 +345,7 @@ class NSSubscriber(object):
             self._subscriber = None
 
 
-class Subscribe(object):
+class Subscribe:
     """Subscriber context.
 
     See :class:`NSSubscriber` and :class:`Subscriber` for initialization parameters.
@@ -397,7 +397,7 @@ def _to_array(obj):
     return obj
 
 
-class _AddressListener(object):
+class _AddressListener:
     """Listener for new addresses of interest."""
 
     def __init__(self, subscriber, services="", nameserver="localhost"):

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -381,7 +381,7 @@ class Subscribe(object):
 
     def __enter__(self):
         """Start the subscriber when used as a context manager."""
-        return self.subscriber.start()
+        return self.subscriber
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Stop the subscriber when used as a context manager."""
@@ -446,7 +446,7 @@ def dict_config(settings):
     """
     if settings.get('addresses') and settings.get('nameserver') is False:
         return _get_subscriber_instance(settings)
-    return _get_nssubscriber_instance(settings)
+    return _get_nssubscriber_instance(settings).start()
 
 
 def _get_subscriber_instance(settings):

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -497,6 +497,95 @@ def _check_valid_settings_in_call(settings, pub_class, ignore=None):
         assert pub_class.call_args[1][key] == settings[key]
 
 
+@mock.patch('posttroll.subscriber.Subscriber')
+@mock.patch('posttroll.subscriber.NSSubscriber')
+def test_dict_config_minimal(NSSubscriber, Subscriber):
+    """Test that without any settings NSSubscriber is created."""
+    from posttroll.subscriber import dict_config
+
+    subscriber = dict_config({})
+    assert subscriber == NSSubscriber.return_value
+    NSSubscriber.assert_called_once()
+    Subscriber.assert_not_called()
+
+
+@mock.patch('posttroll.subscriber.Subscriber')
+@mock.patch('posttroll.subscriber.NSSubscriber')
+def test_dict_config_nameserver_false(NSSubscriber, Subscriber):
+    """Test that NSSubscriber is created with 'localhost' nameserver when no addresses are given."""
+    from posttroll.subscriber import dict_config
+
+    subscriber = dict_config({'nameserver': False})
+    assert subscriber == NSSubscriber.return_value
+    NSSubscriber.assert_called_once()
+    Subscriber.assert_not_called()
+
+
+@mock.patch('posttroll.subscriber.Subscriber')
+@mock.patch('posttroll.subscriber.NSSubscriber')
+def test_dict_config_subscriber(NSSubscriber, Subscriber):
+    """Test that Subscriber is created when nameserver is False and addresses are given."""
+    from posttroll.subscriber import dict_config
+
+    subscriber = dict_config({'nameserver': False, 'addresses': ['addr1']})
+    assert subscriber == Subscriber.return_value
+    Subscriber.assert_called_once()
+    NSSubscriber.assert_not_called()
+
+
+@mock.patch('posttroll.subscriber.Subscriber')
+@mock.patch('posttroll.subscriber.NSSubscriber')
+def test_dict_config_full_nssubscriber(NSSubscriber, Subscriber):
+    """Test that all NSSubscriber options are passed."""
+    from posttroll.subscriber import dict_config
+
+    settings = {
+        "services": "val1",
+        "topics": "val2",
+        "addr_listener": "val3",
+        "addresses": "val4",
+        "timeout": "val5",
+        "translate": "val6",
+        "nameserver": "val7",
+        "message_filter": "val8,"
+    }
+    _ = dict_config(settings)
+    NSSubscriber.assert_called_once_with(
+        services='val1',
+        topics='val2',
+        addr_listener='val3',
+        addresses='val4',
+        timeout='val5',
+        translate='val6',
+        nameserver='val7',
+    )
+
+
+@mock.patch('posttroll.subscriber.Subscriber')
+@mock.patch('posttroll.subscriber.NSSubscriber')
+def test_dict_config_full_subscriber(NSSubscriber, Subscriber):
+    """Test that all Subscriber options are passed."""
+    from posttroll.subscriber import dict_config
+
+    settings = {
+        "services": "val1",
+        "topics": "val2",
+        "addr_listener": "val3",
+        "addresses": "val4",
+        "timeout": "val5",
+        "translate": "val6",
+        "nameserver": False,
+        "message_filter": "val8",
+    }
+    _ = dict_config(settings)
+    Subscriber.assert_called_once_with(
+        'val4',
+        topics='val2',
+        message_filter='val8',
+        translate='val6',
+    )
+
+
 def suite():
     """Collect the test suite for publisher and subsciber tests."""
     loader = unittest.TestLoader()

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -368,6 +368,43 @@ class TestListenerContainer(unittest.TestCase):
         sub.stop()
 
 
+class TestListenerContainerNoNameserver(unittest.TestCase):
+    """Testing listener container without nameserver."""
+
+    def setUp(self):
+        """Set up the testing class."""
+        test_lock.acquire()
+
+    def tearDown(self):
+        """Clean up after the tests have run."""
+        test_lock.release()
+
+    def test_listener_container(self):
+        """Test listener container."""
+        from posttroll.message import Message
+        from posttroll.publisher import Publisher
+        from posttroll.listener import ListenerContainer
+
+        pub_addr = "tcp://127.0.0.1:60000"
+        pub = Publisher(pub_addr, name="test")
+        pub.start()
+        time.sleep(2)
+        sub = ListenerContainer(topics=["/counter"], nameserver=False, addresses=[pub_addr])
+        time.sleep(2)
+        for counter in range(5):
+            tested = False
+            msg_out = Message("/counter", "info", str(counter))
+            pub.send(str(msg_out))
+
+            msg_in = sub.output_queue.get(True, 1)
+            if msg_in is not None:
+                self.assertEqual(str(msg_in), str(msg_out))
+                tested = True
+            self.assertTrue(tested)
+        pub.stop()
+        sub.stop()
+
+
 class TestAddressReceiver(unittest.TestCase):
     """Test the AddressReceiver."""
 

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -449,63 +449,63 @@ class TestPublisherDictConfig(unittest.TestCase):
     @mock.patch('posttroll.publisher.Publisher')
     def test_publisher_is_selected(self, Publisher):
         """Test that Publisher is selected as publisher class."""
-        from posttroll.publisher import dict_config
+        from posttroll.publisher import create_publisher_from_dict_config
 
         settings = {'port': 12345, 'nameservers': False}
 
-        pub = dict_config(settings)
+        pub = create_publisher_from_dict_config(settings)
         Publisher.assert_called_once()
         assert pub is not None
 
     @mock.patch('posttroll.publisher.Publisher')
     def test_publisher_all_arguments(self, Publisher):
         """Test that only valid arguments are passed to Publisher."""
-        from posttroll.publisher import dict_config
+        from posttroll.publisher import create_publisher_from_dict_config
 
         settings = {'port': 12345, 'nameservers': False, 'name': 'foo',
                     'min_port': 40000, 'max_port': 41000, 'invalid_arg': 'bar'}
-        _ = dict_config(settings)
+        _ = create_publisher_from_dict_config(settings)
         _check_valid_settings_in_call(settings, Publisher, ignore=['port', 'nameservers'])
         assert Publisher.call_args[0][0].startswith("tcp://*:")
         assert Publisher.call_args[0][0].endswith(str(settings['port']))
 
     def test_no_name_raises_keyerror(self):
         """Trying to create a NoisyPublisher without a given name will raise KeyError."""
-        from posttroll.publisher import dict_config
+        from posttroll.publisher import create_publisher_from_dict_config
 
         with self.assertRaises(KeyError):
-            _ = dict_config(dict())
+            _ = create_publisher_from_dict_config(dict())
 
     @mock.patch('posttroll.publisher.NoisyPublisher')
     def test_noisypublisher_is_selected_only_name(self, NoisyPublisher):
         """Test that NoisyPublisher is selected as publisher class."""
-        from posttroll.publisher import dict_config
+        from posttroll.publisher import create_publisher_from_dict_config
 
         settings = {'name': 'publisher_name'}
 
-        pub = dict_config(settings)
+        pub = create_publisher_from_dict_config(settings)
         NoisyPublisher.assert_called_once()
         assert pub is not None
 
     @mock.patch('posttroll.publisher.NoisyPublisher')
     def test_noisypublisher_is_selected_name_and_port(self, NoisyPublisher):
         """Test that NoisyPublisher is selected as publisher class."""
-        from posttroll.publisher import dict_config
+        from posttroll.publisher import create_publisher_from_dict_config
 
         settings = {'name': 'publisher_name', 'port': 40000}
 
-        _ = dict_config(settings)
+        _ = create_publisher_from_dict_config(settings)
         NoisyPublisher.assert_called_once()
 
     @mock.patch('posttroll.publisher.NoisyPublisher')
     def test_noisypublisher_all_arguments(self, NoisyPublisher):
         """Test that only valid arguments are passed to NoisyPublisher."""
-        from posttroll.publisher import dict_config
+        from posttroll.publisher import create_publisher_from_dict_config
 
         settings = {'port': 12345, 'nameservers': ['foo'], 'name': 'foo',
                     'min_port': 40000, 'max_port': 41000, 'invalid_arg': 'bar',
                     'aliases': ['alias1', 'alias2'], 'broadcast_interval': 42}
-        _ = dict_config(settings)
+        _ = create_publisher_from_dict_config(settings)
         _check_valid_settings_in_call(settings, NoisyPublisher, ignore=['name'])
         assert NoisyPublisher.call_args[0][0] == settings["name"]
 
@@ -557,9 +557,9 @@ def _check_valid_settings_in_call(settings, pub_class, ignore=None):
 @mock.patch('posttroll.subscriber.NSSubscriber')
 def test_dict_config_minimal(NSSubscriber, Subscriber):
     """Test that without any settings NSSubscriber is created."""
-    from posttroll.subscriber import dict_config
+    from posttroll.subscriber import create_subscriber_from_dict_config
 
-    subscriber = dict_config({})
+    subscriber = create_subscriber_from_dict_config({})
     NSSubscriber.assert_called_once()
     assert subscriber == NSSubscriber().start()
     Subscriber.assert_not_called()
@@ -569,9 +569,9 @@ def test_dict_config_minimal(NSSubscriber, Subscriber):
 @mock.patch('posttroll.subscriber.NSSubscriber')
 def test_dict_config_nameserver_false(NSSubscriber, Subscriber):
     """Test that NSSubscriber is created with 'localhost' nameserver when no addresses are given."""
-    from posttroll.subscriber import dict_config
+    from posttroll.subscriber import create_subscriber_from_dict_config
 
-    subscriber = dict_config({'nameserver': False})
+    subscriber = create_subscriber_from_dict_config({'nameserver': False})
     NSSubscriber.assert_called_once()
     assert subscriber == NSSubscriber().start()
     Subscriber.assert_not_called()
@@ -581,9 +581,9 @@ def test_dict_config_nameserver_false(NSSubscriber, Subscriber):
 @mock.patch('posttroll.subscriber.NSSubscriber')
 def test_dict_config_subscriber(NSSubscriber, Subscriber):
     """Test that Subscriber is created when nameserver is False and addresses are given."""
-    from posttroll.subscriber import dict_config
+    from posttroll.subscriber import create_subscriber_from_dict_config
 
-    subscriber = dict_config({'nameserver': False, 'addresses': ['addr1']})
+    subscriber = create_subscriber_from_dict_config({'nameserver': False, 'addresses': ['addr1']})
     assert subscriber == Subscriber.return_value
     Subscriber.assert_called_once()
     NSSubscriber.assert_not_called()
@@ -593,7 +593,7 @@ def test_dict_config_subscriber(NSSubscriber, Subscriber):
 @mock.patch('posttroll.subscriber.NSSubscriber')
 def test_dict_config_full_nssubscriber(NSSubscriber, Subscriber):
     """Test that all NSSubscriber options are passed."""
-    from posttroll.subscriber import dict_config
+    from posttroll.subscriber import create_subscriber_from_dict_config
 
     settings = {
         "services": "val1",
@@ -605,7 +605,7 @@ def test_dict_config_full_nssubscriber(NSSubscriber, Subscriber):
         "nameserver": "val7",
         "message_filter": "val8,"
     }
-    _ = dict_config(settings)
+    _ = create_subscriber_from_dict_config(settings)
     NSSubscriber.assert_called_once_with(
         services='val1',
         topics='val2',
@@ -621,7 +621,7 @@ def test_dict_config_full_nssubscriber(NSSubscriber, Subscriber):
 @mock.patch('posttroll.subscriber.NSSubscriber')
 def test_dict_config_full_subscriber(NSSubscriber, Subscriber):
     """Test that all Subscriber options are passed."""
-    from posttroll.subscriber import dict_config
+    from posttroll.subscriber import create_subscriber_from_dict_config
 
     settings = {
         "services": "val1",
@@ -633,7 +633,7 @@ def test_dict_config_full_subscriber(NSSubscriber, Subscriber):
         "nameserver": False,
         "message_filter": "val8",
     }
-    _ = dict_config(settings)
+    _ = create_subscriber_from_dict_config(settings)
     Subscriber.assert_called_once_with(
         'val4',
         topics='val2',

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -33,11 +33,10 @@ test_lock = Lock()
 
 
 class TestNS(unittest.TestCase):
-
-    """Test the nameserver.
-    """
+    """Test the nameserver."""
 
     def setUp(self):
+        """Set up the testing class."""
         from posttroll.ns import NameServer
         test_lock.acquire()
         self.ns = NameServer(max_age=timedelta(seconds=3))
@@ -45,6 +44,7 @@ class TestNS(unittest.TestCase):
         self.thr.start()
 
     def tearDown(self):
+        """Clean up after the tests have run."""
         self.ns.stop()
         self.thr.join()
         time.sleep(2)
@@ -77,8 +77,7 @@ class TestNS(unittest.TestCase):
             self.assertTrue("URI" in res[0])
 
     def test_pub_sub_ctx(self):
-        """Test publish and subscribe.
-        """
+        """Test publish and subscribe."""
         from posttroll.message import Message
         from posttroll.publisher import Publish
         from posttroll.subscriber import Subscribe
@@ -122,11 +121,10 @@ class TestNS(unittest.TestCase):
 
 
 class TestNSWithoutMulticasting(unittest.TestCase):
-
-    """Test the nameserver.
-    """
+    """Test the nameserver."""
 
     def setUp(self):
+        """Set up the testing class."""
         from posttroll.ns import NameServer
         test_lock.acquire()
         self.nameservers = ['localhost']
@@ -136,14 +134,14 @@ class TestNSWithoutMulticasting(unittest.TestCase):
         self.thr.start()
 
     def tearDown(self):
+        """Clean up after the tests have run."""
         self.ns.stop()
         self.thr.join()
         time.sleep(2)
         test_lock.release()
 
     def test_pub_addresses(self):
-        """Test retrieving addresses.
-        """
+        """Test retrieving addresses."""
         from posttroll.ns import get_pub_addresses
         from posttroll.publisher import Publish
 
@@ -170,8 +168,7 @@ class TestNSWithoutMulticasting(unittest.TestCase):
             self.assertTrue("URI" in res[0])
 
     def test_pub_sub_ctx(self):
-        """Test publish and subscribe.
-        """
+        """Test publish and subscribe."""
         from posttroll.message import Message
         from posttroll.publisher import Publish
         from posttroll.subscriber import Subscribe
@@ -191,8 +188,7 @@ class TestNSWithoutMulticasting(unittest.TestCase):
         self.assertTrue(tested)
 
     def test_pub_sub_add_rm(self):
-        """Test adding and removing publishers.
-        """
+        """Test adding and removing publishers."""
         from posttroll.publisher import Publish
         from posttroll.subscriber import Subscribe
 
@@ -222,14 +218,15 @@ class TestPubSub(unittest.TestCase):
     """Testing the publishing and subscribing capabilities."""
 
     def setUp(self):
+        """Set up the testing class."""
         test_lock.acquire()
 
     def tearDown(self):
+        """Clean up after the tests have run."""
         test_lock.release()
 
     def test_pub_address_timeout(self):
-        """Test timeout in offline nameserver.
-        """
+        """Test timeout in offline nameserver."""
         from posttroll.ns import get_pub_address
         from posttroll.ns import TimeoutError
 
@@ -237,8 +234,7 @@ class TestPubSub(unittest.TestCase):
                           get_pub_address, ["this_data", 0.5])
 
     def test_pub_suber(self):
-        """Test publisher and subscriber.
-        """
+        """Test publisher and subscriber."""
         from posttroll.message import Message
         from posttroll.publisher import Publisher
         from posttroll.publisher import get_own_ip
@@ -263,17 +259,18 @@ class TestPubSub(unittest.TestCase):
 
 
 class TestPub(unittest.TestCase):
-
-    """Testing the publishing capabilities.
-    """
+    """Testing the publishing capabilities."""
 
     def setUp(self):
+        """Set up the testing class."""
         test_lock.acquire()
 
     def tearDown(self):
+        """Clean up after the tests have run."""
         test_lock.release()
 
     def test_pub_unicode(self):
+        """Test publishing messages in Unicode."""
         from posttroll.message import Message
         from posttroll.publisher import Publish
 
@@ -285,7 +282,7 @@ class TestPub(unittest.TestCase):
                 self.fail("Sending raised UnicodeDecodeError unexpectedly!")
 
     def test_pub_minmax_port(self):
-        """Test user defined port range"""
+        """Test user defined port range."""
         import os
 
         # Using environment variables to set port range
@@ -330,10 +327,10 @@ def _get_port(min_port=None, max_port=None):
 
 
 class TestListenerContainer(unittest.TestCase):
-
-    """Testing listener container"""
+    """Testing listener container."""
 
     def setUp(self):
+        """Set up the testing class."""
         from posttroll.ns import NameServer
         test_lock.acquire()
         self.ns = NameServer(max_age=timedelta(seconds=3))
@@ -341,13 +338,14 @@ class TestListenerContainer(unittest.TestCase):
         self.thr.start()
 
     def tearDown(self):
+        """Clean up after the tests have run."""
         self.ns.stop()
         self.thr.join()
         time.sleep(2)
         test_lock.release()
 
     def test_listener_container(self):
-        """Test listener container"""
+        """Test listener container."""
         from posttroll.message import Message
         from posttroll.publisher import NoisyPublisher
         from posttroll.listener import ListenerContainer
@@ -377,6 +375,7 @@ class TestAddressReceiver(unittest.TestCase):
     @mock.patch("posttroll.address_receiver.Publish")
     @mock.patch("posttroll.address_receiver.MulticastReceiver")
     def test_localhost_restriction(self, mcrec, pub, msg):
+        """Test address receiver restricted only to localhost."""
         mcr_instance = mock.Mock()
         mcrec.return_value = mcr_instance
         mcr_instance.return_value = 'blabla', ('255.255.255.255', 12)
@@ -499,8 +498,7 @@ def _check_valid_settings_in_call(settings, pub_class, ignore=None):
 
 
 def suite():
-    """The suite for test_bbmcast.
-    """
+    """Collect the test suite for publisher and subsciber tests."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestPubSub))

--- a/posttroll/tests/test_pubsub.py
+++ b/posttroll/tests/test_pubsub.py
@@ -589,9 +589,8 @@ def test_dict_config_subscriber(NSSubscriber, Subscriber):
     NSSubscriber.assert_not_called()
 
 
-@mock.patch('posttroll.subscriber.Subscriber')
-@mock.patch('posttroll.subscriber.NSSubscriber')
-def test_dict_config_full_nssubscriber(NSSubscriber, Subscriber):
+@mock.patch('posttroll.subscriber.NSSubscriber.start')
+def test_dict_config_full_nssubscriber(NSSubscriber_start):
     """Test that all NSSubscriber options are passed."""
     from posttroll.subscriber import create_subscriber_from_dict_config
 
@@ -606,20 +605,12 @@ def test_dict_config_full_nssubscriber(NSSubscriber, Subscriber):
         "message_filter": "val8,"
     }
     _ = create_subscriber_from_dict_config(settings)
-    NSSubscriber.assert_called_once_with(
-        services='val1',
-        topics='val2',
-        addr_listener='val3',
-        addresses='val4',
-        timeout='val5',
-        translate='val6',
-        nameserver='val7',
-    )
+    # The subscriber should have been started
+    NSSubscriber_start.assert_called_once()
 
 
-@mock.patch('posttroll.subscriber.Subscriber')
-@mock.patch('posttroll.subscriber.NSSubscriber')
-def test_dict_config_full_subscriber(NSSubscriber, Subscriber):
+@mock.patch('posttroll.subscriber.Subscriber.update')
+def test_dict_config_full_subscriber(Subscriber_update):
     """Test that all Subscriber options are passed."""
     from posttroll.subscriber import create_subscriber_from_dict_config
 
@@ -634,12 +625,6 @@ def test_dict_config_full_subscriber(NSSubscriber, Subscriber):
         "message_filter": "val8",
     }
     _ = create_subscriber_from_dict_config(settings)
-    Subscriber.assert_called_once_with(
-        'val4',
-        topics='val2',
-        message_filter='val8',
-        translate='val6',
-    )
 
 
 def suite():


### PR DESCRIPTION
Similarly to https://github.com/pytroll/posttroll/pull/35 , this PR adds the possibility to configure the subscriber using a dictionary of config options. In this way it is possible to disable `nameserver` connection in the `ListenerContainer` when it is not needed, or is otherwise undesirable.

The subscriber class without `nameserver` connection is selected by setting `nameserver=False` and giving a non-empty list of connection addresses. In all other cases the default `NSSubscriber` will be used.

This PR is required by https://github.com/pytroll/pytroll-collectors/pull/102