### PR TITLE
Instruct to create annotated tags

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ Don't forget to commit!
 5. Create a tag with the new version number, starting with a 'v', eg:
 
 ```
-git tag v0.22.45
+git tag -a v0.22.45 -m "Version 0.22.45"
 ```
 
 See [semver.org](http://semver.org/) on how to write a version number.


### PR DESCRIPTION
Simple addition to release instructions, where `git tag -a` needs to be used so that `git push --follow-tags` will work.