### PR TITLE
Set TCP keepalive to publisher and subscriber

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -115,6 +115,30 @@ to specify the nameserver(s) explicitly in the publishing code::
 .. seealso:: :class:`posttroll.publisher.Publish`
              and :class:`posttroll.subscriber.Subscribe`
 
+Setting TCP keep-alive
+----------------------
+
+If the network connection between a publisher and a subscriber seem to
+be dropping, it is possible to set TCP keep-alive settings via environment
+variables. Below are some rudimentary example values::
+
+    import os
+
+    os.environ["POSTTROLL_TCP_KEEPALIVE"] = "1"
+    os.environ["POSTTROLL_TCP_KEEPALIVE_CNT"] = "10"
+    os.environ["POSTTROLL_TCP_KEEPALIVE_IDLE"] = "1"
+    os.environ["POSTTROLL_TCP_KEEPALIVE_INTVL"] = "1"
+
+These values need to be set before any subscriber/publisher are
+created to have them take any effect. Another option is to set these
+in the shell initialization, like ``$HOME/.bashrc``.
+
+For further information on the 0MQ TCP keep-alive, see zmq_setsockopts_ for
+relevant socket options.
+
+.. _zmq_setsockopts: http://api.zeromq.org/master:zmq-setsockopt
+
+
 Converting from older posttroll versions
 ----------------------------------------
 

--- a/posttroll/__init__.py
+++ b/posttroll/__init__.py
@@ -1,34 +1,37 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2010-2012, 2014.
-
+#
 # Author(s):
-
+#
 #   Lars Ø. Rasmussen <ras@dmi.dk>
 #   Martin Raspaud <martin.raspaud@smhi.se>
-
+#   Panu Lahtinen <panu.lahtinen@fmi.fi>
+#
 # This file is part of pytroll.
-
+#
 # Pytroll is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software
 # Foundation, either version 3 of the License, or (at your option) any later
 # version.
-
+#
 # Pytroll is distributed in the hope that it will be useful, but WITHOUT ANY
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
 # A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License along with
 # pytroll.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Posttroll packages."""
 
 import sys
 
 from datetime import datetime
-import _strptime
 import os
-import zmq
 import logging
 from .version import get_versions
+
+import zmq
 
 context = {}
 logger = logging.getLogger(__name__)
@@ -48,6 +51,7 @@ def get_context():
 
 def strp_isoformat(strg):
     """Decode an ISO formatted string to a datetime object.
+
     Allow a time-string without microseconds.
 
     We handle input like: 2011-11-14T12:51:25.123456
@@ -57,7 +61,7 @@ def strp_isoformat(strg):
     if len(strg) < 19 or len(strg) > 26:
         if len(strg) > 30:
             strg = strg[:30] + '...'
-        raise ValueError("Invalid ISO formatted time string '%s'"%strg)
+        raise ValueError("Invalid ISO formatted time string '%s'" % strg)
     if strg.find(".") == -1:
         strg += '.000000'
     if sys.version[0:3] >= '2.6':
@@ -67,6 +71,21 @@ def strp_isoformat(strg):
         dat = datetime.strptime(dat, "%Y-%m-%dT%H:%M:%S")
         mis = int(float('.' + mis)*1000000)
         return dat.replace(microsecond=mis)
+
+
+def _set_tcp_keepalive(socket):
+    keepalive = os.environ.get("POSTTROLL_TCP_KEEPALIVE")
+    if keepalive is not None:
+        socket.setsockopt(zmq.TCP_KEEPALIVE, int(keepalive))
+    keepalive_cnt = os.environ.get("POSTTROLL_TCP_KEEPALIVE_CNT")
+    if keepalive_cnt is not None:
+        socket.setsockopt(zmq.TCP_KEEPALIVE_CNT, int(keepalive_cnt))
+    keepalive_idle = os.environ.get("POSTTROLL_TCP_KEEPALIVE_IDLE")
+    if keepalive_idle is not None:
+        socket.setsockopt(zmq.TCP_KEEPALIVE_IDLE, int(keepalive_idle))
+    keepalive_intvl = os.environ.get("POSTTROLL_TCP_KEEPALIVE_INTVL")
+    if keepalive_intvl is not None:
+        socket.setsockopt(zmq.TCP_KEEPALIVE_INTVL, int(keepalive_intvl))
 
 
 __version__ = get_versions()['version']

--- a/posttroll/publisher.py
+++ b/posttroll/publisher.py
@@ -32,6 +32,7 @@ from urllib.parse import urlsplit, urlunsplit
 import zmq
 
 from posttroll import get_context
+from posttroll import _set_tcp_keepalive
 from posttroll.message import Message
 from posttroll.message_broadcaster import sendaddressservice
 
@@ -94,10 +95,7 @@ class Publisher:
         self.name = name
         self.destination = address
         self.publish = get_context().socket(zmq.PUB)
-        self.publish.setsockopt(zmq.TCP_KEEPALIVE, 1)
-        self.publish.setsockopt(zmq.TCP_KEEPALIVE_CNT, 10)
-        self.publish.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 1)
-        self.publish.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 1)
+        _set_tcp_keepalive(self.publish)
 
         # Limit port range or use the defaults when no port is defined
         # by the user

--- a/posttroll/publisher.py
+++ b/posttroll/publisher.py
@@ -94,6 +94,10 @@ class Publisher:
         self.name = name
         self.destination = address
         self.publish = get_context().socket(zmq.PUB)
+        self.publish.setsockopt(zmq.TCP_KEEPALIVE, 1)
+        self.publish.setsockopt(zmq.TCP_KEEPALIVE_CNT, 10)
+        self.publish.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 1)
+        self.publish.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 1)
 
         # Limit port range or use the defaults when no port is defined
         # by the user
@@ -295,7 +299,7 @@ def create_publisher_from_dict_config(settings):
       running on those servers, and in addition publish the messages on a random port on the
       localhost
 
-    - setting *settings['port']* to zero and *settings['namservers']* to *None* will broadcast
+    - setting *settings['port']* to zero and *settings['nameservers']* to *None* will broadcast
       the publisher address and port with multicast, and publish the messages on a random port.
 
     The last two cases will require *settings['name']* to be set. Additional options are

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -32,6 +32,7 @@ from threading import Lock
 from urllib.parse import urlsplit
 
 # pylint: disable=E0611
+import zmq
 from zmq import LINGER, NOBLOCK, POLLIN, PULL, SUB, SUBSCRIBE, Poller, ZMQError
 
 # pylint: enable=E0611
@@ -99,6 +100,10 @@ class Subscriber:
             LOGGER.info("Subscriber adding address %s with topics %s",
                         str(address), str(topics))
             subscriber = get_context().socket(SUB)
+            subscriber.setsockopt(zmq.TCP_KEEPALIVE, 1)
+            subscriber.setsockopt(zmq.TCP_KEEPALIVE_CNT, 10)
+            subscriber.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 1)
+            subscriber.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 1)
             for t__ in topics:
                 subscriber.setsockopt_string(SUBSCRIBE, str(t__))
             subscriber.connect(address)

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -32,11 +32,11 @@ from threading import Lock
 from urllib.parse import urlsplit
 
 # pylint: disable=E0611
-import zmq
 from zmq import LINGER, NOBLOCK, POLLIN, PULL, SUB, SUBSCRIBE, Poller, ZMQError
 
 # pylint: enable=E0611
 from posttroll import get_context
+from posttroll import _set_tcp_keepalive
 from posttroll.message import _MAGICK, Message
 from posttroll.ns import get_pub_address
 
@@ -100,10 +100,7 @@ class Subscriber:
             LOGGER.info("Subscriber adding address %s with topics %s",
                         str(address), str(topics))
             subscriber = get_context().socket(SUB)
-            subscriber.setsockopt(zmq.TCP_KEEPALIVE, 1)
-            subscriber.setsockopt(zmq.TCP_KEEPALIVE_CNT, 10)
-            subscriber.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 1)
-            subscriber.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 1)
+            _set_tcp_keepalive(subscriber)
             for t__ in topics:
                 subscriber.setsockopt_string(SUBSCRIBE, str(t__))
             subscriber.connect(address)


### PR DESCRIPTION
This PR adds a TCP keepalive to the publisher and subscriber. They can be controlled via environment variables
- `POSTTROLL_TCP_KEEPALIVE`
- `POSTTROLL_TCP_KEEPALIVE_CNT`
- `POSTTROLL_TCP_KEEPALIVE_IDLE`
- `POSTTROLL_TCP_KEEPALIVE_INTVL`

I have no idea what the default values should be, I just tested with something I found while searching (1/10/1/1 respectively). I opted to not to do anything if the env variables are not set.

My use case is on running containers on OpenShift, where the socket connections seem to be timing out unless there is a relatively constant stream of messages. Without these settings I got four messages of collected MSG/RSS scenes on the first try, and seven on the second try. With theses settings, the segment gatherer messages have been passing consistently over-night.

Similar broken/dead connections have occured in other places, but not this often.