### PR TITLE
Make testing's patched_subscriber_recv  interruptible

### DIFF
--- a/posttroll/testing.py
+++ b/posttroll/testing.py
@@ -1,11 +1,20 @@
 """Testing utilities."""
 from contextlib import contextmanager
 
+
 @contextmanager
 def patched_subscriber_recv(messages):
     """Patch the Subscriber object to return given messages."""
     from unittest import mock
-    with mock.patch("posttroll.subscriber.Subscriber.recv", mock.Mock(return_value=messages)):
+
+    def interuptible_recv(self):
+        """Yield message until the subscriber is closed."""
+        for msg in messages:
+            if self._loop is False:
+                break
+            yield msg
+
+    with mock.patch("posttroll.subscriber.Subscriber.recv", interuptible_recv):
         yield
 
 @contextmanager


### PR DESCRIPTION
This makes it possible to catch cases when the subscriber is closed before all expected messages have arrived.