### PR TITLE
Crash fake publisher when not started

### DIFF
--- a/posttroll/publisher.py
+++ b/posttroll/publisher.py
@@ -109,8 +109,7 @@ class Publisher:
 
 
     def start(self):
-        """Start the publisher.
-        """
+        """Start the publisher."""
         self.publish_socket = get_context().socket(zmq.PUB)
         _set_tcp_keepalive(self.publish_socket)
 

--- a/posttroll/testing.py
+++ b/posttroll/testing.py
@@ -24,10 +24,15 @@ def patched_publisher():
     published = []
 
     def fake_send(self, message):
+        if getattr(self, "test_pub_started", None) is None:
+            raise RuntimeError("Cannot 'send' before the publisher is started.")
         published.append(message)
+
+    def fake_start(self, *args, **kwargs):
+        self.test_pub_started = True
 
     def noop(self, *args, **kwargs):
         pass
 
-    with mock.patch.multiple("posttroll.publisher.Publisher", send=fake_send, start=noop, stop=noop):
+    with mock.patch.multiple("posttroll.publisher.Publisher", send=fake_send, start=fake_start, stop=noop):
         yield published

--- a/posttroll/tests/test_testing.py
+++ b/posttroll/tests/test_testing.py
@@ -1,6 +1,9 @@
+import pytest
 from posttroll.testing import patched_publisher
 
+
 def test_fake_publisher():
+    """Test running a fake publisher."""
     from posttroll.publisher import create_publisher_from_dict_config
 
     with patched_publisher() as messages:
@@ -9,3 +12,13 @@ def test_fake_publisher():
         pub.send("bla")
         pub.stop()
         assert "bla" in messages
+
+
+def test_fake_publisher_crashes_when_not_started():
+    """Test fake publisher needs to be started."""
+    from posttroll.publisher import create_publisher_from_dict_config
+
+    with patched_publisher():
+        pub = create_publisher_from_dict_config(dict(port=1979, nameservers=False))
+        with pytest.raises(RuntimeError):
+            pub.send("bla")


### PR DESCRIPTION
Fake publisher needs to crash when not started to mimic the behaviour of the real publishers