### PR TITLE
Fix Flake8 complaints and datetime imports

### DIFF
--- a/posttroll/__init__.py
+++ b/posttroll/__init__.py
@@ -24,10 +24,10 @@
 
 """Posttroll packages."""
 
+import datetime as dt
 import logging
 import os
 import sys
-from datetime import datetime
 
 import zmq
 from donfig import Config
@@ -58,7 +58,7 @@ def strp_isoformat(strg):
 
     We handle input like: 2011-11-14T12:51:25.123456
     """
-    if isinstance(strg, datetime):
+    if isinstance(strg, dt.datetime):
         return strg
     if len(strg) < 19 or len(strg) > 26:
         if len(strg) > 30:
@@ -67,10 +67,10 @@ def strp_isoformat(strg):
     if strg.find(".") == -1:
         strg += '.000000'
     if sys.version[0:3] >= '2.6':
-        return datetime.strptime(strg, "%Y-%m-%dT%H:%M:%S.%f")
+        return dt.datetime.strptime(strg, "%Y-%m-%dT%H:%M:%S.%f")
     else:
         dat, mis = strg.split(".")
-        dat = datetime.strptime(dat, "%Y-%m-%dT%H:%M:%S")
+        dat = dt.datetime.strptime(dat, "%Y-%m-%dT%H:%M:%S")
         mis = int(float('.' + mis)*1000000)
         return dat.replace(microsecond=mis)
 

--- a/posttroll/address_receiver.py
+++ b/posttroll/address_receiver.py
@@ -58,6 +58,7 @@ zero_seconds = timedelta(seconds=0)
 
 
 def get_local_ips():
+    """Get local IP addresses."""
     inet_addrs = [netifaces.ifaddresses(iface).get(netifaces.AF_INET)
                   for iface in netifaces.interfaces()]
     ips = []
@@ -79,6 +80,7 @@ class AddressReceiver(object):
 
     def __init__(self, max_age=ten_minutes, port=None,
                  do_heartbeat=True, multicast_enabled=True, restrict_to_localhost=False):
+        """Initialize addres receiver."""
         self._max_age = max_age
         self._port = port or default_publish_port
         self._address_lock = threading.Lock()
@@ -196,8 +198,7 @@ class AddressReceiver(object):
                             pub.heartbeat(min_interval=29)
                     msg = Message.decode(data)
                     name = msg.subject.split("/")[1]
-                    if(msg.type == 'info' and
-                       msg.subject.lower().startswith(self._subject)):
+                    if msg.type == 'info' and msg.subject.lower().startswith(self._subject):
                         addr = msg.data["URI"]
                         msg.data['status'] = True
                         metadata = copy.copy(msg.data)
@@ -222,15 +223,16 @@ class AddressReceiver(object):
 
 
 class _SimpleReceiver(object):
-
-    """ Simple listing on port for address messages."""
+    """Simple listing on port for address messages."""
 
     def __init__(self, port=None):
+        """Initialize receiver."""
         self._port = port or default_publish_port
         self._socket = get_context().socket(REP)
         self._socket.bind("tcp://*:" + str(port))
 
     def __call__(self):
+        """Receive and return a message."""
         message = self._socket.recv_string()
         self._socket.send_string("ok")
         return message, None

--- a/posttroll/address_receiver.py
+++ b/posttroll/address_receiver.py
@@ -27,13 +27,12 @@ It will look like:
 /<server-name>/address info ... host:port
 """
 import copy
+import datetime as dt
+import errno
 import logging
 import os
 import threading
-import errno
 import time
-
-from datetime import datetime, timedelta
 
 import netifaces
 from zmq import REP, LINGER
@@ -53,8 +52,8 @@ broadcast_port = 21200
 
 default_publish_port = 16543
 
-ten_minutes = timedelta(minutes=10)
-zero_seconds = timedelta(seconds=0)
+ten_minutes = dt.timedelta(minutes=10)
+zero_seconds = dt.timedelta(seconds=0)
 
 
 def get_local_ips():
@@ -88,7 +87,7 @@ class AddressReceiver(object):
         self._subject = '/address'
         self._do_heartbeat = do_heartbeat
         self._multicast_enabled = multicast_enabled
-        self._last_age_check = datetime(1900, 1, 1)
+        self._last_age_check = dt.datetime(1900, 1, 1)
         self._do_run = False
         self._is_running = False
         self._thread = threading.Thread(target=self._run)
@@ -127,11 +126,11 @@ class AddressReceiver(object):
 
     def _check_age(self, pub, min_interval=zero_seconds):
         """Check the age of the receiver."""
-        now = datetime.utcnow()
+        now = dt.datetime.utcnow()
         if (now - self._last_age_check) <= min_interval:
             return
 
-        LOGGER.debug("%s - checking addresses", str(datetime.utcnow()))
+        LOGGER.debug("%s - checking addresses", str(dt.datetime.utcnow()))
         self._last_age_check = now
         to_del = []
         with self._address_lock:
@@ -218,7 +217,7 @@ class AddressReceiver(object):
     def _add(self, adr, metadata):
         """Add an address."""
         with self._address_lock:
-            metadata["receive_time"] = datetime.utcnow()
+            metadata["receive_time"] = dt.datetime.utcnow()
             self._addresses[adr] = metadata
 
 

--- a/posttroll/bbmcast.py
+++ b/posttroll/bbmcast.py
@@ -60,12 +60,14 @@ class MulticastSender(object):
     """Multicast sender on *port* and *mcgroup*."""
 
     def __init__(self, port, mcgroup=MC_GROUP):
+        """Initialize multicast sending."""
         self.port = port
         self.group = mcgroup
         self.socket, self.group = mcast_sender(mcgroup)
         logger.debug('Started multicast group %s', mcgroup)
 
     def __call__(self, data):
+        """Send data to a socket."""
         self.socket.sendto(data.encode(), (self.group, self.port))
 
     def close(self):
@@ -76,16 +78,14 @@ class MulticastSender(object):
 
 
 def mcast_sender(mcgroup=MC_GROUP):
-    """Non-object interface for sending multicast messages.
-    """
+    """Non-object interface for sending multicast messages."""
     sock = socket(AF_INET, SOCK_DGRAM)
     try:
         sock.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
         if _is_broadcast_group(mcgroup):
             group = '<broadcast>'
             sock.setsockopt(SOL_SOCKET, SO_BROADCAST, 1)
-        elif((int(mcgroup.split(".")[0]) > 239) or
-             (int(mcgroup.split(".")[0]) < 224)):
+        elif int(mcgroup.split(".")[0]) > 239 or int(mcgroup.split(".")[0]) < 224:
             raise IOError("Invalid multicast address.")
         else:
             group = mcgroup
@@ -105,20 +105,25 @@ def mcast_sender(mcgroup=MC_GROUP):
 
 class MulticastReceiver(object):
     """Multicast receiver on *port* for an *mcgroup*."""
+
     BUFSIZE = 1024
 
     def __init__(self, port, mcgroup=MC_GROUP):
+        """Initialize multicast receiver."""
         # Note: a multicast receiver will also receive broadcast on same port.
         self.port = port
         self.socket, self.group = mcast_receiver(port, mcgroup)
 
     def settimeout(self, tout=None):
-        """A timeout will throw a 'socket.timeout'.
+        """Set timeout.
+
+        A timeout will throw a 'socket.timeout'.
         """
         self.socket.settimeout(tout)
         return self
 
     def __call__(self):
+        """Receive data from a socket."""
         data, sender = self.socket.recvfrom(self.BUFSIZE)
         return data.decode(), sender
 
@@ -131,9 +136,7 @@ class MulticastReceiver(object):
 
 
 def mcast_receiver(port, mcgroup=MC_GROUP):
-    """Open a UDP socket, bind it to a port and select a multicast group.
-    """
-
+    """Open a UDP socket, bind it to a port and select a multicast group."""
     if _is_broadcast_group(mcgroup):
         group = None
     else:
@@ -184,8 +187,7 @@ def mcast_receiver(port, mcgroup=MC_GROUP):
 
 
 def _is_broadcast_group(group):
-    """Check if *group* is a valid multicasting group.
-    """
+    """Check if *group* is a valid multicasting group."""
     if not group or gethostbyname(group) in ('0.0.0.0', '255.255.255.255'):
         return True
     return False

--- a/posttroll/logger.py
+++ b/posttroll/logger.py
@@ -1,27 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+#
 # Copyright (c) 2012, 2014, 2015 Martin Raspaud
-
+#
 # Author(s):
-
+#
 #   Martin Raspaud <martin.raspaud@smhi.se>
-
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Logger for pytroll system.
-"""
+"""Logger module for Posttroll."""
 
 
 # TODO: remove old hanging subscriptions
@@ -39,14 +38,14 @@ LOGGER = logging.getLogger(__name__)
 
 
 class PytrollFormatter(logging.Formatter):
-
-    """Formats a pytroll message inside a log record.
-    """
+    """Formats a pytroll message inside a log record."""
 
     def __init__(self, fmt, datefmt):
+        """Initialize formatter."""
         logging.Formatter.__init__(self, fmt, datefmt)
 
     def format(self, record):
+        """Format the message."""
         subject = "/".join(("log", record.levelname, str(record.name)))
         mesg = Message(subject, "log." + str(record.levelname).lower(),
                        record.getMessage())
@@ -54,20 +53,21 @@ class PytrollFormatter(logging.Formatter):
 
 
 class PytrollHandler(logging.Handler):
-
-    """Sends the record through a pytroll publisher.
-    """
+    """Sends the record through a pytroll publisher."""
 
     def __init__(self, name, port=0):
+        """Initialize the handler."""
         logging.Handler.__init__(self)
         self._publisher = NoisyPublisher(name, port)
         self._publisher.start()
 
     def emit(self, record):
+        """Emit the message."""
         message = self.format(record)
         self._publisher.send(message)
 
     def close(self):
+        """Close the handler."""
         self._publisher.stop()
         logging.Handler.close(self)
 
@@ -87,15 +87,15 @@ RESET_SEQ = "\033[0m"
 
 
 class ColoredFormatter(logging.Formatter):
-
-    """Adds a color for the levelname.
-    """
+    """Adds a color for the levelname."""
 
     def __init__(self, msg, use_color=True):
+        """Initialize the colored formatter."""
         logging.Formatter.__init__(self, msg)
         self.use_color = use_color
 
     def format(self, record):
+        """Format the message."""
         levelname = record.levelname
         if self.use_color and levelname in COLORS:
             levelname_color = (COLOR_SEQ % (30 + COLORS[levelname])
@@ -105,30 +105,24 @@ class ColoredFormatter(logging.Formatter):
         return logging.Formatter.format(self, record2)
 
 
-# logging.basicConfig(format='[%(asctime)s %(levelname)s] %(message)s',
-#                    level=logging.DEBUG)
-
-
 class Logger(object):
-
     """The logging machine.
 
     Contains a thread listening to incomming messages, and a thread logging.
     """
 
     def __init__(self, nameserver_address="localhost", nameserver_port=16543):
+        """Initialize the logger."""
         del nameserver_address, nameserver_port
         self.log_thread = Thread(target=self.log)
         self.loop = True
 
     def start(self):
-        """Starts the logging.
-        """
+        """Start the logging."""
         self.log_thread.start()
 
     def log(self):
-        """Log stuff.
-        """
+        """Log stuff."""
         with Subscribe(services=[""], addr_listener=True) as sub:
             for msg in sub.recv(1):
                 if msg:
@@ -156,14 +150,12 @@ class Logger(object):
                     break
 
     def stop(self):
-        """Stop the machine.
-        """
+        """Stop the machine."""
         self.loop = False
 
 
 def run():
-    """Main function
-    """
+    """Run the logger."""
     import argparse
 
     global LOGGER
@@ -209,8 +201,8 @@ def run():
             time.sleep(1)
     except KeyboardInterrupt:
         tlogger.stop()
-        print("Thanks for using pytroll/logger. "
-              "See you soon on www.pytroll.org!")
+        print("Thanks for using pytroll/logger. See you soon on www.pytroll.org!")
+
 
 if __name__ == '__main__':
     run()

--- a/posttroll/message.py
+++ b/posttroll/message.py
@@ -38,8 +38,9 @@ will be encoded as (at the right time and by the right user at the right host)::
 Note: the Message class is not optimized for BIG messages.
 """
 
+import datetime as dt
 import re
-from datetime import datetime
+
 try:
     import json
 except ImportError:
@@ -131,7 +132,7 @@ class Message(object):
                 self.type = atype
             self.type = atype
             self.sender = _getsender()
-            self.time = datetime.utcnow()
+            self.time = dt.datetime.utcnow()
             self.data = data
             self.binary = binary
         self.version = _VERSION

--- a/posttroll/message_broadcaster.py
+++ b/posttroll/message_broadcaster.py
@@ -1,25 +1,27 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2010-2012, 2014, 2015.
-
+#
 # Author(s):
-
+#
 #   Lars Ø. Rasmussen <ras@dmi.dk>
 #   Martin Raspaud    <martin.raspaud@smhi.se>
-
+#
 # This file is part of pytroll.
-
+#
 # Pytroll is free software: you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software
 # Foundation, either version 3 of the License, or (at your option) any later
 # version.
-
+#
 # Pytroll is distributed in the hope that it will be useful, but WITHOUT ANY
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
 # A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License along with
 # pytroll.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Message broadcast module."""
 
 import time
 import threading
@@ -42,11 +44,12 @@ class DesignatedReceiversSender(object):
     """Sends message to multiple *receivers* on *port*."""
 
     def __init__(self, default_port, receivers):
+        """Set settings."""
         self.default_port = default_port
-
         self.receivers = receivers
 
     def __call__(self, data):
+        """Send messages from all receivers."""
         for receiver in self.receivers:
             self._send_to_address(receiver, data)
 
@@ -71,11 +74,13 @@ class DesignatedReceiversSender(object):
     def close(self):
         """Close the sender."""
         pass
-#-----------------------------------------------------------------------------
+
+
+# ----------------------------------------------------------------------------
 #
 # General thread to broadcast messages.
 #
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 
 class MessageBroadcaster(object):
@@ -85,6 +90,7 @@ class MessageBroadcaster(object):
     """
 
     def __init__(self, msg, port, interval, designated_receivers=None):
+        """Initialize message broadcaster."""
         if designated_receivers:
             self._sender = DesignatedReceiversSender(port,
                                                      designated_receivers)
@@ -140,17 +146,19 @@ class MessageBroadcaster(object):
             self._is_running = False
             self._sender.close()
 
-#-----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
 #
 # General thread to broadcast addresses.
 #
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 
 class AddressBroadcaster(MessageBroadcaster):
     """Class to broadcast stuff."""
 
     def __init__(self, name, address, interval, nameservers):
+        """Initialize address broadcasting."""
         msg = message.Message("/address/%s" % name, "info",
                               {"URI": "%s:%d" % address}).encode()
         MessageBroadcaster.__init__(self, msg, broadcast_port, interval,
@@ -172,6 +180,7 @@ class AddressServiceBroadcaster(MessageBroadcaster):
     """Class to broadcast stuff."""
 
     def __init__(self, name, address, data_type, interval=2, nameservers=None):
+        """Initialize broadcaster."""
         msg = message.Message("/address/%s" % name, "info",
                               {"URI": address,
                                "service": data_type}).encode()

--- a/posttroll/ns.py
+++ b/posttroll/ns.py
@@ -25,10 +25,10 @@
 
 Default port is 5557, if $NAMESERVER_PORT is not defined.
 """
+import datetime as dt
 import logging
 import os
 import time
-from datetime import datetime, timedelta
 
 from threading import Lock
 # pylint: disable=E0611
@@ -67,8 +67,8 @@ def get_pub_addresses(names=None, timeout=10, nameserver="localhost"):
     if names is None:
         names = ["", ]
     for name in names:
-        then = datetime.now() + timedelta(seconds=timeout)
-        while datetime.now() < then:
+        then = dt.datetime.now() + dt.timedelta(seconds=timeout)
+        while dt.datetime.now() < then:
             addrs += get_pub_address(name, nameserver=nameserver, timeout=timeout)
             if addrs:
                 break
@@ -127,7 +127,7 @@ class NameServer:
         """Initialize nameserver."""
         self.loop = True
         self.listener = None
-        self._max_age = max_age or timedelta(minutes=10)
+        self._max_age = max_age or dt.timedelta(minutes=10)
         self._multicast_enabled = multicast_enabled
         self._restrict_to_localhost = restrict_to_localhost
 

--- a/posttroll/ns.py
+++ b/posttroll/ns.py
@@ -47,17 +47,21 @@ logger = logging.getLogger(__name__)
 
 nslock = Lock()
 
-class TimeoutError(BaseException):
 
+class TimeoutError(BaseException):
     """A timeout."""
+
     pass
 
 # Client functions.
 
 
 def get_pub_addresses(names=None, timeout=10, nameserver="localhost"):
-    """Get the address of the publisher for a given list of publisher *names*
-    from the nameserver on *nameserver* (localhost by default).
+    """Get the addresses of the publishers.
+
+    Kwargs:
+    - names: names of the publishers
+    - nameserver: nameserver address to query the publishers from (default: localhost).
     """
     addrs = []
     if names is None:
@@ -73,8 +77,12 @@ def get_pub_addresses(names=None, timeout=10, nameserver="localhost"):
 
 
 def get_pub_address(name, timeout=10, nameserver="localhost"):
-    """Get the address of the publisher for a given publisher *name* from the
-    nameserver on *nameserver* (localhost by default)."""
+    """Get the address of the named publisher.
+
+    Kwargs:
+    - name: name of the publishers
+    - nameserver: nameserver address to query the publishers from (default: localhost).
+    """
     # Socket to talk to server
     socket = get_context().socket(REQ)
     try:
@@ -104,8 +112,7 @@ def get_pub_address(name, timeout=10, nameserver="localhost"):
 
 
 def get_active_address(name, arec):
-    """Get the addresses of the active modules for a given publisher *name*.
-    """
+    """Get the addresses of the active modules for a given publisher *name*."""
     addrs = arec.get(name)
     if addrs:
         return Message("/oper/ns", "info", addrs)
@@ -116,16 +123,16 @@ def get_active_address(name, arec):
 class NameServer:
     """The name server."""
 
-    def __init__(self, max_age=timedelta(minutes=10), multicast_enabled=True, restrict_to_localhost=False):
+    def __init__(self, max_age=None, multicast_enabled=True, restrict_to_localhost=False):
+        """Initialize nameserver."""
         self.loop = True
         self.listener = None
-        self._max_age = max_age
+        self._max_age = max_age or timedelta(minutes=10)
         self._multicast_enabled = multicast_enabled
         self._restrict_to_localhost = restrict_to_localhost
 
     def run(self, *args):
-        """Run the listener and answer to requests.
-        """
+        """Run the listener and answer to requests."""
         del args
 
         arec = AddressReceiver(max_age=self._max_age,
@@ -161,8 +168,7 @@ class NameServer:
             self.stop()
 
     def stop(self):
-        """Stop the name server.
-        """
+        """Stop the name server."""
         self.listener.setsockopt(LINGER, 1)
         self.loop = False
         with nslock:

--- a/posttroll/publisher.py
+++ b/posttroll/publisher.py
@@ -23,9 +23,9 @@
 
 """The publisher module gives high-level tools to publish messages on a port."""
 
+import datetime as dt
 import logging
 import socket
-from datetime import datetime, timedelta
 from threading import Lock
 from urllib.parse import urlsplit, urlunsplit
 import zmq
@@ -160,13 +160,13 @@ class _PublisherHeartbeat:
     def __init__(self, publisher):
         self.publisher = publisher
         self.subject = '/heartbeat/' + publisher.name
-        self.lastbeat = datetime(1900, 1, 1)
+        self.lastbeat = dt.datetime(1900, 1, 1)
 
     def __call__(self, min_interval=0):
         if not min_interval or (
-            (datetime.utcnow() - self.lastbeat >=
-             timedelta(seconds=min_interval))):
-            self.lastbeat = datetime.utcnow()
+            (dt.datetime.utcnow() - self.lastbeat >=
+             dt.timedelta(seconds=min_interval))):
+            self.lastbeat = dt.datetime.utcnow()
             LOGGER.debug("Publish heartbeat (min_interval is %.1f sec)", min_interval)
             self.publisher.send(Message(self.subject, "beat",
                                         {"min_interval": min_interval}).encode())

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -176,7 +176,6 @@ class Subscriber:
         self._hooks.append(socket)
         self._hooks_cb[socket] = callback
 
-
     @property
     def addresses(self):
         """Get the addresses."""
@@ -365,6 +364,7 @@ class Subscribe:
     information how the selection is done.
 
     Example::
+            del tmp
 
         from posttroll.subscriber import Subscribe
 

--- a/posttroll/subscriber.py
+++ b/posttroll/subscriber.py
@@ -24,10 +24,10 @@
 
 """Simple library to subscribe to messages."""
 
-from time import sleep
+import datetime as dt
 import logging
 import time
-from datetime import datetime, timedelta
+from time import sleep
 from threading import Lock
 from urllib.parse import urlsplit
 
@@ -311,8 +311,8 @@ class NSSubscriber:
         """Start the subscriber."""
         def _get_addr_loop(service, timeout):
             """Try to get the address of *service* until for *timeout* seconds."""
-            then = datetime.now() + timedelta(seconds=timeout)
-            while datetime.now() < then:
+            then = dt.datetime.now() + dt.timedelta(seconds=timeout)
+            while dt.datetime.now() < then:
                 addrs = get_pub_address(service, nameserver=self._nameserver)
                 if addrs:
                     return [addr["URI"] for addr in addrs]

--- a/posttroll/testing.py
+++ b/posttroll/testing.py
@@ -17,6 +17,7 @@ def patched_subscriber_recv(messages):
     with mock.patch("posttroll.subscriber.Subscriber.recv", interuptible_recv):
         yield
 
+
 @contextmanager
 def patched_publisher():
     """Patch the Subscriber object to return given messages."""

--- a/posttroll/tests/test_message.py
+++ b/posttroll/tests/test_message.py
@@ -21,8 +21,7 @@
 # You should have received a copy of the GNU General Public License along with
 # pytroll.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Test module for the message class.
-"""
+"""Test module for the message class."""
 
 import os
 import sys
@@ -47,13 +46,10 @@ SOME_METADATA = {'timestamp': datetime(2010, 12, 3, 16, 28, 39),
 
 
 class Test(unittest.TestCase):
-
-    """Test class.
-    """
+    """Test class."""
 
     def test_encode_decode(self):
-        """Test the encoding/decoding of the message class.
-        """
+        """Test the encoding/decoding of the message class."""
         msg1 = Message('/test/whatup/doc', 'info', data='not much to say')
 
         sender = '%s@%s' % (msg1.user, msg1.host)
@@ -64,8 +60,7 @@ class Test(unittest.TestCase):
                         msg='Messaging, encoding, decoding failed')
 
     def test_decode(self):
-        """Test the decoding of a message.
-        """
+        """Test the decoding of a message."""
         rawstr = (_MAGICK +
                   r'/test/1/2/3 info ras@hawaii 2008-04-11T22:13:22.123000 v1.01' +
                   r' text/ascii "what' + r"'" + r's up doc"')
@@ -75,8 +70,7 @@ class Test(unittest.TestCase):
                         msg='Messaging, decoding of message failed')
 
     def test_encode(self):
-        """Test the encoding of a message.
-        """
+        """Test the encoding of a message."""
         subject = '/test/whatup/doc'
         atype = "info"
         data = 'not much to say'
@@ -114,7 +108,8 @@ class Test(unittest.TestCase):
 
     def test_iso(self):
         """Test handling of iso-8859-1."""
-        msg = 'pytroll://oper/polar/direct_readout/norrköping pong sat@MERLIN 2019-01-07T12:52:19.872171 v1.01 application/json {"station": "norrköping"}'
+        msg = ('pytroll://oper/polar/direct_readout/norrköping pong sat@MERLIN '
+               '2019-01-07T12:52:19.872171 v1.01 application/json {"station": "norrköping"}')
         try:
             iso_msg = msg.decode('utf-8').encode('iso-8859-1')
         except AttributeError:
@@ -125,8 +120,7 @@ class Test(unittest.TestCase):
             self.fail('Unexpected iso decoding error')
 
     def test_pickle(self):
-        """Test pickling.
-        """
+        """Test pickling."""
         import pickle
         msg1 = Message('/test/whatup/doc', 'info', data='not much to say')
         try:
@@ -146,8 +140,7 @@ class Test(unittest.TestCase):
                 pass
 
     def test_metadata(self):
-        """Test metadata encoding/decoding.
-        """
+        """Test metadata encoding/decoding."""
         metadata = copy.copy(SOME_METADATA)
         msg = Message.decode(Message('/sat/polar/smb/level1', 'file',
                                      data=metadata).encode())
@@ -156,8 +149,7 @@ class Test(unittest.TestCase):
                         msg='Messaging, metadata decoding / encoding failed')
 
     def test_serialization(self):
-        """Test json serialization.
-        """
+        """Test json serialization."""
         compare_file = '/message_metadata.dumps'
         try:
             import json
@@ -181,13 +173,13 @@ class Test(unittest.TestCase):
 
 
 def suite():
-    """The suite for test_message.
-    """
+    """Create the suite for test_message."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(Test))
 
     return mysuite
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/posttroll/tests/test_testing.py
+++ b/posttroll/tests/test_testing.py
@@ -25,6 +25,7 @@ def test_fake_publisher_crashes_when_not_started():
         with pytest.raises(RuntimeError):
             pub.send("bla")
 
+
 def test_fake_publisher_crashes_when_send_is_used_with_non_string_type():
     """Test fake publisher needs to be started."""
     from posttroll.publisher import create_publisher_from_dict_config


### PR DESCRIPTION
This PR fixes flake8 complaints and fixes the datetime imports. This is a precursor work for https://github.com/pytroll/posttroll/issues/64

We can't do `from datetime import datetime` because it overwrites the module name thus making subsequent imports from `datetime` impossible.