### PR TITLE
Fix typo in secure backend documentation

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -162,7 +162,7 @@ On the server side (for example a publisher), we need to define the server's sec
 accepted client keys are provided::
 
    POSTTROLL_SERVER_SECRET_KEY_FILE=/path/to/server.key_secret
-   POSTTROLL_PUBLIC_SECRET_KEYS_DIRECTORY=/path/to/client_public_keys/
+   POSTTROLL_CLIENTS_PUBLIC_KEYS_DIRECTORY=/path/to/client_public_keys/
 
 On the client side (for example a subscriber), we need to define the server's public key file and the client's secret
 key file::

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -173,7 +173,7 @@ key file::
 These settings can also be set using the posttroll config object, for example::
 
    >>> from posttroll import config
-   >>> with config.set(backend="secure_zmq", server_pubic_key_file="..."):
+   >>> with config.set(backend="secure_zmq", server_public_key_file="..."):
    ...
 
 The posttroll configuration uses donfig, for more information, check https://donfig.readthedocs.io/en/latest/.


### PR DESCRIPTION
A couple of typos crept in the documentation. This PR fixes them.