### PR TITLE
Reintroduce global get_context

### DIFF
--- a/posttroll/__init__.py
+++ b/posttroll/__init__.py
@@ -25,9 +25,26 @@
 """Posttroll packages."""
 
 import logging
+from warnings import warn
 
 from donfig import Config
 
 config = Config("posttroll", defaults=[dict(backend="unsecure_zmq")])
 
 logger = logging.getLogger(__name__)
+
+
+def get_context():
+    """Provide the context to use.
+
+    This function takes care of creating new contexts in case of forks.
+    """
+    warn("Posttroll's get_context function is deprecated. If you really need it, import the corresponding backend's"
+         " get_context instead",
+         stacklevel=2)
+    backend = config["backend"]
+    if "zmq" in backend:
+        from posttroll.backends.zmq import get_context
+        return get_context()
+    else:
+        raise NotImplementedError(f"No support for backend {backend} implemented (yet?).")

--- a/posttroll/tests/conftest.py
+++ b/posttroll/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Module for common pytest fixtures."""
+
+import pytest
+import zmq
+
+import posttroll.backends.zmq.socket
+
+
+@pytest.fixture(autouse=True)
+def new_context(monkeypatch):
+    """Create a new context for each test."""
+    context = zmq.Context()
+    def get_context():
+        return context
+    monkeypatch.setattr(posttroll.backends.zmq.socket, "get_context", get_context)
+    yield
+    context.term()
+
+


### PR DESCRIPTION
This was removed overlooking that eg trollmoves was using it.